### PR TITLE
TypeScript moved to dependencies

### DIFF
--- a/packages/uxpin-code-cli/package.json
+++ b/packages/uxpin-code-cli/package.json
@@ -71,7 +71,6 @@
     "ts-jest": "^22.4.4",
     "tslint": "^5.9.1",
     "tslint-config-uxpin": "^1.7.0",
-    "typescript": "^2.5.2",
     "webpack-cli": "^2.1.3"
   },
   "dependencies": {
@@ -99,6 +98,7 @@
     "sortobject": "^1.1.1",
     "source-map-support": "^0.4.18",
     "tslib": "^1.9.0",
+    "typescript": "^2.5.2",
     "webpack": "^4.8.1",
     "webpack-merge": "^4.1.2"
   }


### PR DESCRIPTION
it's required by react-docgen-typescript