### PR TITLE
16546: Allow running a test against an existing experimental server

### DIFF
--- a/packages/uxpin-merge-cli/test/utils/experimentation/experimentationServerTestSetupOptions.ts
+++ b/packages/uxpin-merge-cli/test/utils/experimentation/experimentationServerTestSetupOptions.ts
@@ -9,6 +9,7 @@ export interface ExperimentationServerOptionsWithDefaults {
   env?:CmdOptions['env'];
   port:number;
   useTempDir:boolean;
+  useExistingServer?:ExistingServerConfiguration;
 }
 
 export const defaultOptions:ExperimentationServerOptionsWithDefaults = {
@@ -16,3 +17,8 @@ export const defaultOptions:ExperimentationServerOptionsWithDefaults = {
   projectPath: 'resources/designSystems/noSrcDir',
   useTempDir: true,
 };
+
+export interface ExistingServerConfiguration {
+  port:number;
+  projectPath:string;
+}

--- a/packages/uxpin-merge-cli/test/utils/experimentation/getServerConfiguration.ts
+++ b/packages/uxpin-merge-cli/test/utils/experimentation/getServerConfiguration.ts
@@ -15,10 +15,14 @@ export interface ExperimentationServerConfiguration {
 export async function getServerConfiguration(
   opts:ExperimentationServerTestSetupOptions,
 ):Promise<ExperimentationServerConfiguration> {
-  const { useTempDir, projectPath, port, serverCmdArgs, env } = defaults(opts, defaultOptions);
+  const { useTempDir, projectPath, port, serverCmdArgs, env, useExistingServer } = defaults(opts, defaultOptions);
   let workingDir:string = resolveTestProjectPath(projectPath);
   let cleanupTemp:() => void = noop;
-  if (useTempDir) {
+  let serverPort:number = port;
+  if (useExistingServer) {
+    workingDir = resolveTestProjectPath(useExistingServer.projectPath);
+    serverPort = useExistingServer.port;
+  } else if (useTempDir) {
     const tempDir:DirectoryResult = await prepareTempDir(workingDir);
     workingDir = tempDir.path;
     cleanupTemp = tempDir.cleanup;
@@ -30,7 +34,7 @@ export async function getServerConfiguration(
       env,
       params: [...(serverCmdArgs || []), `--port=${port}`],
     },
-    port,
+    port: serverPort,
     workingDir,
   };
 }


### PR DESCRIPTION
Option only for temporary use.
Useful for running tests against the server run with a connected debugger