### PR TITLE
Print version immediately

### DIFF
--- a/packages/uxpin-merge-cli/src/program/command/version/applyVersionCommandSteps.ts
+++ b/packages/uxpin-merge-cli/src/program/command/version/applyVersionCommandSteps.ts
@@ -1,9 +1,0 @@
-import { Step } from '../Step';
-import { getVersionCommandSteps } from './getVersionCommandSteps';
-
-export function applyVersionCommandSteps(steps:Step[]):Step[] {
-  return [
-    ...getVersionCommandSteps(),
-    ...steps,
-  ];
-}

--- a/packages/uxpin-merge-cli/src/program/command/version/getVersionCommandSteps.ts
+++ b/packages/uxpin-merge-cli/src/program/command/version/getVersionCommandSteps.ts
@@ -1,8 +1,0 @@
-import { printCurrentVersionInfo } from '../../utils/version/printCurrentVersion';
-import { Step } from '../Step';
-
-export function getVersionCommandSteps():Step[] {
-  return [
-    { exec: printCurrentVersionInfo, shouldRun: true },
-  ];
-}

--- a/packages/uxpin-merge-cli/src/program/runProgram.ts
+++ b/packages/uxpin-merge-cli/src/program/runProgram.ts
@@ -9,14 +9,15 @@ import { Command } from './command/Command';
 import { getSteps } from './command/getSteps';
 import { getStepsForWatcher } from './command/getStepsForWatcher';
 import { Step, StepExecutor } from './command/Step';
-import { applyVersionCommandSteps } from './command/version/applyVersionCommandSteps';
 import { DSMetadata } from './DSMeta';
 import { setNodeEnv } from './env/setNodeEnv';
+import { printCurrentVersionInfo } from './utils/version/printCurrentVersion';
 import { setupWatcher } from './watcher/setupWatcher';
 
 export async function runProgram(program:RawProgramArgs):Promise<any> {
   try {
     setNodeEnv(process.env.UXPIN_ENV);
+    printCurrentVersionInfo();
     const programArgs:ProgramArgs = getProgramArgs(program);
     await setupProjectWatcher(programArgs);
     await runCommand(programArgs);
@@ -26,7 +27,7 @@ export async function runProgram(program:RawProgramArgs):Promise<any> {
 }
 
 async function runCommand(programArgs:ProgramArgs):Promise<any> {
-  await executeCommandSteps(programArgs, applyVersionCommandSteps(getSteps(programArgs)));
+  await executeCommandSteps(programArgs, getSteps(programArgs));
 }
 
 async function setupProjectWatcher(programArgs:ProgramArgs):Promise<void> {
@@ -62,12 +63,12 @@ function isWatchChangesCommand(programArgs:ProgramArgs):boolean {
   return programArgs.command === Command.EXPERIMENT;
 }
 
-function endWithError(error:Error|string):void {
+function endWithError(error:Error | string):void {
   logError(error);
 
   process.exit(1);
 }
 
-function logError(error:Error|string):void {
+function logError(error:Error | string):void {
   console.error('ERROR:', error instanceof Error ? error.message : error);
 }

--- a/packages/uxpin-merge-cli/src/program/utils/version/printCurrentVersion.ts
+++ b/packages/uxpin-merge-cli/src/program/utils/version/printCurrentVersion.ts
@@ -1,6 +1,7 @@
 import * as safe from 'colors/safe';
-import { isTestEnv } from '../../../program/env/isTestEnv';
 import { printLine } from '../../../utils/console/printLine';
+import { PrintOptions } from '../../../utils/console/PrintOptions';
+import { isTestEnv } from '../../env/isTestEnv';
 import { getToolVersion } from './getToolVersion';
 
 export function printCurrentVersionInfo():void {
@@ -8,9 +9,10 @@ export function printCurrentVersionInfo():void {
     return;
   }
 
-  printLine('');
-  printLine(getCurrentVersionInfo());
-  printLine('');
+  const options:PrintOptions = { channel: 'stderr' };
+  printLine('', options);
+  printLine(getCurrentVersionInfo(), options);
+  printLine('', options);
 }
 
 function getCurrentVersionInfo():string {

--- a/packages/uxpin-merge-cli/src/utils/console/PrintOptions.ts
+++ b/packages/uxpin-merge-cli/src/utils/console/PrintOptions.ts
@@ -1,6 +1,9 @@
+type OutStreamName = 'stdout' | 'stderr';
+
 export interface PrintOptions {
   color?:PrintColor;
   underline?:boolean;
+  channel?:OutStreamName;
 }
 
 export enum PrintColor {

--- a/packages/uxpin-merge-cli/src/utils/console/print.ts
+++ b/packages/uxpin-merge-cli/src/utils/console/print.ts
@@ -1,22 +1,29 @@
 import { PrintColor, PrintOptions } from './PrintOptions';
 
-export function print(message:string, options:PrintOptions = {}):void {
+export function print(
+  message:string,
+  {
+    channel = 'stdout',
+    underline = false,
+    color,
+  }:PrintOptions = {},
+):void {
   let msg:string = message;
-  if (options.underline) {
-    msg = underline(message);
+  if (underline) {
+    msg = applyUnderline(message);
   }
 
-  if (options.color) {
-    msg = color(msg, options.color);
+  if (color) {
+    msg = applyColor(msg, color);
   }
 
-  process.stdout.write(msg);
+  process[channel].write(msg);
 }
 
-function underline(text:string):string {
+function applyUnderline(text:string):string {
   return `\x1b[4m${text}\x1b[0m`;
 }
 
-function color(text:string, printColor:PrintColor):string {
+function applyColor(text:string, printColor:PrintColor):string {
   return `\x1b[${printColor}m${text}\x1b[0m`;
 }


### PR DESCRIPTION
Two changes:
1. Version is printed immediately - previously was run as a first step which was causing that we waited for correct serialization, and in case something went wrong in components discovery or serialization, verion was never printed,
2. Version is printed to stderr – in general, `stdout` is for transfering data that can be later consumed by other piped command, and [`stderr` is for communication with user](https://www.jstorimer.com/blogs/workingwithcode/7766119-when-to-use-stderr-instead-of-stdout). It was uncomfortable especially when using `uxpin-merge dump > dump.json` which was putting version log at the begginning of the JSON file causing a syntax error. Now in such case version is printed into the console, while the pure JSON dump is correctly saved in a file.