### PR TITLE
throw error on missing `uxpId` property in RCC in preset

### DIFF
--- a/packages/uxpin-merge-cli/src/steps/serialization/component/presets/collectPresetElements.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/presets/collectPresetElements.ts
@@ -19,6 +19,11 @@ export function collectPresetElements(
   }
 
   const { children, name, props: { uxpId, ...props } } = element;
+
+  if (!uxpId) {
+    throw new Error('Missing `uxpId` property');
+  }
+
   elementsCollector.result[uxpId] = {
     name,
     props: {


### PR DESCRIPTION
https://uxpin.tpondemand.com/entity/19677-cli-print-error-on-preset-without 