### PR TITLE
Add the tags file generated by Ctags to the gitignore file

### DIFF
--- a/packages/uxpin-merge-cli/.gitignore
+++ b/packages/uxpin-merge-cli/.gitignore
@@ -15,6 +15,7 @@
 !/test/resources/repos/.gitkeep
 /reports/*
 !/reports/.gitkeep
+tags
 
 !/test/resources/configs/*.js
 !/test/resources/components/**/*.js


### PR DESCRIPTION
I use Ctags with Vim so that I can search the codebase. Just adding the generated `tags` file to the gitignore.