### PR TITLE
Fix Typescript Arrow Consts needing using the filename

### DIFF
--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/getComponentName.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/getComponentName.ts
@@ -1,8 +1,14 @@
 import { TSSerializationContext } from '../context/getSerializationContext';
 import { getComponentFileName } from './getComponentFileName';
 import { ComponentDeclaration } from './getPropsTypeAndDefaultProps';
+import * as ts from 'typescript'
 
 export function getComponentName(context:TSSerializationContext, component:ComponentDeclaration):string {
-  return component.name && component.name.getText()
-    || getComponentFileName(context);
+  if(component.name) {
+    return component.name.getText()
+  }
+  if (ts.isArrowFunction(component) && component.parent && (component.parent as ts.ArrowFunction).name){
+    return ((component.parent as ts.ArrowFunction).name as ts.Identifier).getText()
+  }
+  return getComponentFileName(context);
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/getComponentName.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/getComponentName.ts
@@ -1,16 +1,17 @@
+import { ArrowFunction, Identifier, isArrowFunction } from 'typescript';
 import { TSSerializationContext } from '../context/getSerializationContext';
 import { getComponentFileName } from './getComponentFileName';
 import { ComponentDeclaration } from './getPropsTypeAndDefaultProps';
-import { ArrowFunction, isArrowFunction, Identifier } from 'typescript';
 
 export function getComponentName(context:TSSerializationContext, component:ComponentDeclaration):string {
   if (component.name) {
-    return component.name.getText()
+    return component.name.getText();
   }
   // Support named arrow functions and use the component parent's name.
   // https://github.com/UXPin/uxpin-merge-tools/issues/208
-  if (isArrowFunction(component) && component.parent && "name" in component.parent && (component.parent as ArrowFunction).name) {
-    return ((component.parent as ArrowFunction).name as Identifier).getText()
+  if (isArrowFunction(component) && component.parent &&
+      'name' in component.parent && (component.parent as ArrowFunction).name) {
+    return ((component.parent as ArrowFunction).name as Identifier).getText();
   }
   return getComponentFileName(context);
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/getComponentName.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/getComponentName.ts
@@ -9,8 +9,8 @@ export function getComponentName(context:TSSerializationContext, component:Compo
   }
   // Support named arrow functions and use the component parent's name.
   // https://github.com/UXPin/uxpin-merge-tools/issues/208
-  if (ts.isArrowFunction(component) && component.parent && "name" in component.parent && (component.parent as ts.ArrowFunction).name) {
-    return ((component.parent as ts.ArrowFunction).name as ts.Identifier).getText()
+  if (isArrowFunction(component) && component.parent && "name" in component.parent && (component.parent as ArrowFunction).name) {
+    return ((component.parent as ArrowFunction).name as Identifier).getText()
   }
   return getComponentFileName(context);
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/getComponentName.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/getComponentName.ts
@@ -1,13 +1,15 @@
 import { TSSerializationContext } from '../context/getSerializationContext';
 import { getComponentFileName } from './getComponentFileName';
 import { ComponentDeclaration } from './getPropsTypeAndDefaultProps';
-import * as ts from 'typescript'
+import { ArrowFunction, isArrowFunction, Identifier } from 'typescript';
 
 export function getComponentName(context:TSSerializationContext, component:ComponentDeclaration):string {
-  if(component.name) {
+  if (component.name) {
     return component.name.getText()
   }
-  if (ts.isArrowFunction(component) && component.parent && (component.parent as ts.ArrowFunction).name){
+  // Support named arrow functions and use the component parent's name.
+  // https://github.com/UXPin/uxpin-merge-tools/issues/208
+  if (ts.isArrowFunction(component) && component.parent && "name" in component.parent && (component.parent as ts.ArrowFunction).name) {
     return ((component.parent as ts.ArrowFunction).name as ts.Identifier).getText()
   }
   return getComponentFileName(context);


### PR DESCRIPTION
This PR should fix the fact that the latest release of Arrow names needs the filenames to be in ProperCase because the arrow-function implementation is a child of the actual component. This means that in getComponentName it was falling back to the filename and dumping components such as `import simple-select from '../src/components/simple-select.tsx` in the components.js file in the .uxpin-merge

I don't think it will affect any other way of importing when using typescript.