### PR TITLE
Ts datetime type

### DIFF
--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/ComponentPropertyDefinition.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/ComponentPropertyDefinition.ts
@@ -62,6 +62,7 @@ export interface PropertyTypeStructureMap {
   array:{};
   boolean:{};
   custom:{};
+  date:{};
   element:{};
   func:FunctionStructure;
   literal:{ value:string | number | ts.PseudoBigInt };

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/__tests__/getComponentMetadata.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/__tests__/getComponentMetadata.test.ts
@@ -45,6 +45,12 @@ describe('getComponentMetadata – integration', () => {
           {
             description: '',
             isRequired: true,
+            name: 'dateProp',
+            type: { name: 'date', structure: {} },
+          },
+          {
+            description: '',
+            isRequired: true,
             name: 'elementProp',
             type: { name: 'element', structure: {} },
           },

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent.test.ts
@@ -117,26 +117,6 @@ describe('serializeTSComponent', () => {
       });
     });
 
-    // it('serializes class component with empty date property', () => {
-    //   // given
-    //   const component:ComponentImplementationInfo = getImplementation('ClassWithEmptyDateType');
-    //   const expectedMetadata:ComponentMetadata = {
-    //     name: 'ClassWithEmptyDateType',
-    //     namespace: undefined,
-    //     properties: [
-    //
-    //     ],
-    //     wrappers: [],
-    //   };
-    //
-    //   // when
-    //   return serializeTSComponent(component).then((serializedProps) => {
-    //     // then
-    //     expect(serializedProps.result).toEqual(expectedMetadata);
-    //     expect(serializedProps.warnings).toEqual([]);
-    //   });
-    // });
-
     it('serializes class component with enum property types', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('ClassEnumTypes');

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent.test.ts
@@ -48,6 +48,95 @@ describe('serializeTSComponent', () => {
       });
     });
 
+    it('serializes class component with date property ', () => {
+      const isoRegex:RegExp = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*))(?:Z|(\+|-)([\d|:]*))?$/;
+
+      // given
+      const component:ComponentImplementationInfo = getImplementation('ClassWithDateType');
+      const expectedMetadata:ComponentMetadata = {
+        name: 'ClassWithDateType',
+        namespace: undefined,
+        properties: [
+          {
+            defaultValue: {
+              value: '2016-07-19T20:23:01.804Z',
+            },
+            description: 'Dates only',
+            isRequired: true,
+            name: 'dateInteger',
+            type: {
+              name: 'date',
+              structure: {},
+            },
+          },
+          {
+            defaultValue: {
+              value: '2010-08-08T00:00:00.000Z',
+            },
+            description: '',
+            isRequired: true,
+            name: 'dateString',
+            type: {
+              name: 'date',
+              structure: {},
+            },
+          },
+          {
+            defaultValue: {
+              value: expect.stringMatching(isoRegex),
+            },
+            description: '',
+            isRequired: true,
+            name: 'dateEmpty',
+            type: {
+              name: 'date',
+              structure: {},
+            },
+          },
+          {
+            defaultValue: {
+              value: '1997-08-07T05:00:00.000Z',
+            },
+            description: '',
+            isRequired: true,
+            name: 'dateRest',
+            type: {
+              name: 'date',
+              structure: {},
+            },
+          },
+        ],
+        wrappers: [],
+      };
+
+      // when
+      return serializeTSComponent(component).then((serializedProps) => {
+        // then
+        expect(serializedProps.result).toEqual(expectedMetadata);
+        expect(serializedProps.warnings).toEqual([]);
+      });
+    });
+
+    // it('serializes class component with empty date property', () => {
+    //   // given
+    //   const component:ComponentImplementationInfo = getImplementation('ClassWithEmptyDateType');
+    //   const expectedMetadata:ComponentMetadata = {
+    //     name: 'ClassWithEmptyDateType',
+    //     namespace: undefined,
+    //     properties: [
+    //
+    //     ],
+    //     wrappers: [],
+    //   };
+    //
+    //   // when
+    //   return serializeTSComponent(component).then((serializedProps) => {
+    //     // then
+    //     expect(serializedProps.result).toEqual(expectedMetadata);
+    //     expect(serializedProps.warnings).toEqual([]);
+    //   });
+    // });
+
     it('serializes class component with enum property types', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('ClassEnumTypes');

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent.test.ts
@@ -49,8 +49,6 @@ describe('serializeTSComponent', () => {
     });
 
     it('serializes class component with date property ', () => {
-      const isoRegex:RegExp = /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/;
-
       // given
       const component:ComponentImplementationInfo = getImplementation('ClassWithDateType');
       const expectedMetadata:ComponentMetadata = {
@@ -83,19 +81,7 @@ describe('serializeTSComponent', () => {
           },
           {
             defaultValue: {
-              value: expect.stringMatching(isoRegex),
-            },
-            description: '',
-            isRequired: true,
-            name: 'dateEmpty',
-            type: {
-              name: 'date',
-              structure: {},
-            },
-          },
-          {
-            defaultValue: {
-              value: '1997-02-01T00:01:01.001Z',
+              value: '1997-02-01T01:01:01.001Z',
             },
             description: '',
             isRequired: true,
@@ -113,6 +99,27 @@ describe('serializeTSComponent', () => {
       return serializeTSComponent(component).then((serializedProps) => {
         // then
         expect(serializedProps.result).toEqual(expectedMetadata);
+        expect(serializedProps.warnings).toEqual([]);
+      });
+    });
+
+    it('serializes class component with empty date property ', () => {
+      // given
+      const component:ComponentImplementationInfo = getImplementation('ClassWithEmptyDateType');
+      // when
+      return serializeTSComponent(component).then((serializedProps) => {
+        // then
+        expect(serializedProps.result).toEqual(expect.objectContaining({
+          name: expect.any(String),
+          properties: expect.arrayContaining([
+            expect.objectContaining({
+              defaultValue: expect.objectContaining({
+                value: expect.any(String),
+              }),
+            }),
+          ]),
+          wrappers: expect.any(Array),
+        }));
         expect(serializedProps.warnings).toEqual([]);
       });
     });

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent.test.ts
@@ -49,7 +49,7 @@ describe('serializeTSComponent', () => {
     });
 
     it('serializes class component with date property ', () => {
-      const isoRegex:RegExp = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*))(?:Z|(\+|-)([\d|:]*))?$/;
+      const isoRegex:RegExp = /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/;
 
       // given
       const component:ComponentImplementationInfo = getImplementation('ClassWithDateType');
@@ -95,7 +95,7 @@ describe('serializeTSComponent', () => {
           },
           {
             defaultValue: {
-              value: '1997-08-07T05:00:00.000Z',
+              value: '1997-02-01T00:01:01.001Z',
             },
             description: '',
             isRequired: true,

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/defaultValue/getDefaultPropertyValue.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/defaultValue/getDefaultPropertyValue.ts
@@ -29,9 +29,8 @@ export function getDefaultValueFromNewExpression(
   propertyInitializer:ts.NewExpression,
 ):SupportedDefaultValue | undefined {
   if (propertyInitializer.arguments &&
-      (propertyInitializer.expression as ts.Identifier).escapedText == 'Date') {
-
-    const dateProps:unknown[] = propertyInitializer.arguments
+      (propertyInitializer.expression as ts.Identifier).escapedText === 'Date') {
+    const dateProps:Array<unknown> = propertyInitializer.arguments
       .map((argument):string | number | undefined => {
         switch (argument.kind) {
           case ts.SyntaxKind.StringLiteral:

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/defaultValue/getDefaultPropertyValue.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/defaultValue/getDefaultPropertyValue.ts
@@ -43,8 +43,7 @@ export function getDefaultValueFromNewExpression(
         }
       });
 
-    // @ts-ignore
-    return new Date(...dateProps).toJSON();
+    return new Date(...dateProps as [number, number, number, number, number, number]).toJSON();
   }
 
   return false;

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/defaultValue/getDefaultPropertyValue.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/defaultValue/getDefaultPropertyValue.ts
@@ -18,9 +18,22 @@ export function getDefaultPropertyValue(
       return false;
     case ts.SyntaxKind.Identifier:
       return getDefaultValueFromIdentifier(context, valueInitializer as ts.Identifier);
+    case ts.SyntaxKind.NewExpression:
+      return getDefaultValueFromNewExpression(context, valueInitializer as ts.NewExpression);
     default:
       return;
   }
+}
+
+export function getDefaultValueFromNewExpression(
+  context:TSSerializationContext,
+  propertyInitializer:any,
+):SupportedDefaultValue | undefined {
+  if (propertyInitializer.expression.escapedText == 'Date') {
+    return new Date(propertyInitializer.arguments[0].text).toJSON();
+  }
+
+  return false;
 }
 
 export function getDefaultValueFromIdentifier(

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/property/type/node/serializeKnownPropertyType.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/property/type/node/serializeKnownPropertyType.ts
@@ -3,9 +3,9 @@ import { PropertyType } from '../../../../ComponentPropertyDefinition';
 
 export const KNOWN_TYPES_MAP:{ [typeName:string]:PropertyType } = {
   Array: { name: 'array', structure: {} },
+  Date: { name: 'date', structure: {} },
   ReactElement: { name: 'element', structure: {} },
   ReactNode: { name: 'node', structure: {} },
-  Date: { name: 'date', structure: {} },
 };
 
 export function serializeKnownPropertyType(type:ts.Type):PropertyType {

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/property/type/node/serializeKnownPropertyType.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/property/type/node/serializeKnownPropertyType.ts
@@ -5,6 +5,7 @@ export const KNOWN_TYPES_MAP:{ [typeName:string]:PropertyType } = {
   Array: { name: 'array', structure: {} },
   ReactElement: { name: 'element', structure: {} },
   ReactNode: { name: 'node', structure: {} },
+  Date: { name: 'date', structure: {} },
 };
 
 export function serializeKnownPropertyType(type:ts.Type):PropertyType {

--- a/packages/uxpin-merge-cli/src/utils/fs/PresetFileGenerator/helpers/getDefaultValueForPropType.ts
+++ b/packages/uxpin-merge-cli/src/utils/fs/PresetFileGenerator/helpers/getDefaultValueForPropType.ts
@@ -13,6 +13,7 @@ const propTypesToValuesMap:GetDefaultValueForPropType = {
   array:[],
   boolean:false,
   custom:null,
+  date:new Date(),
   dictionary:null,
   element:null,
   empty:'',

--- a/packages/uxpin-merge-cli/test/resources/components/typescript/ClassWithDateType.tsx
+++ b/packages/uxpin-merge-cli/test/resources/components/typescript/ClassWithDateType.tsx
@@ -16,7 +16,7 @@ export default class ClassWithDateType extends React.Component<Props> {
     dateInteger: new Date(1468959781804),
     dateString: new Date("2010-08-08"),
     dateEmpty: new Date(),
-    dateRest: new Date(1997, 7, 7, 7),
+    dateRest: new Date(1997, 1, 1, 1, 1, 1, 1),
   };
 
   public render():JSX.Element {

--- a/packages/uxpin-merge-cli/test/resources/components/typescript/ClassWithDateType.tsx
+++ b/packages/uxpin-merge-cli/test/resources/components/typescript/ClassWithDateType.tsx
@@ -6,7 +6,6 @@ export interface Props {
    */
   dateInteger:Date;
   dateString:Date;
-  dateEmpty:Date;
   dateRest:Date;
 }
 
@@ -15,21 +14,18 @@ export default class ClassWithDateType extends React.Component<Props> {
   public static defaultProps:Partial<Props> = {
     dateInteger: new Date(1468959781804),
     dateString: new Date("2010-08-08"),
-    dateEmpty: new Date(),
     dateRest: new Date(1997, 1, 1, 1, 1, 1, 1),
   };
 
   public render():JSX.Element {
-    const { dateInteger, dateString, dateEmpty, dateRest } = this.props;
+    const { dateInteger, dateString, dateRest } = this.props;
     let isoInteger = dateInteger.toISOString().split('T')[0];
     let isoString = dateString.toISOString().split('T')[0];
-    let isoEmpty = dateEmpty.toISOString().split('T')[0];
     let isoRest = dateRest.toISOString().split('T')[0];
     return (
       <label>
         <input type="date" value={isoInteger}/>
         <input type="date" value={isoString}/>
-        <input type="date" value={isoEmpty}/>
         <input type="date" value={isoRest}/>
       </label>
     );

--- a/packages/uxpin-merge-cli/test/resources/components/typescript/ClassWithDateType.tsx
+++ b/packages/uxpin-merge-cli/test/resources/components/typescript/ClassWithDateType.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+
+export interface Props {
+  /**
+   * Dates only
+   */
+  dateInteger:Date;
+  dateString:Date;
+  dateEmpty:Date;
+  dateRest:Date;
+}
+
+export default class ClassWithDateType extends React.Component<Props> {
+
+  public static defaultProps:Partial<Props> = {
+    dateInteger: new Date(1468959781804),
+    dateString: new Date("2010-08-08"),
+    dateEmpty: new Date(),
+    dateRest: new Date(1997, 7, 7, 7),
+  };
+
+  public render():JSX.Element {
+    const { dateInteger, dateString, dateEmpty, dateRest } = this.props;
+    let isoInteger = dateInteger.toISOString().split('T')[0];
+    let isoString = dateString.toISOString().split('T')[0];
+    let isoEmpty = dateEmpty.toISOString().split('T')[0];
+    let isoRest = dateRest.toISOString().split('T')[0];
+    return (
+      <label>
+        <input type="date" value={isoInteger}/>
+        <input type="date" value={isoString}/>
+        <input type="date" value={isoEmpty}/>
+        <input type="date" value={isoRest}/>
+      </label>
+    );
+  }
+}

--- a/packages/uxpin-merge-cli/test/resources/components/typescript/ClassWithEmptyDateType.tsx
+++ b/packages/uxpin-merge-cli/test/resources/components/typescript/ClassWithEmptyDateType.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+export interface Props {
+  dateEmpty:Date;
+}
+
+export default class ClassWithEmptyDateType extends React.Component<Props> {
+
+  public static defaultProps:Partial<Props> = {
+    dateEmpty: new Date(),
+  };
+
+  public render():JSX.Element {
+    const { dateEmpty } = this.props;
+    let isoEmpty = dateEmpty.toISOString().split('T')[0];
+    return (
+      <label>
+        <input type="date" value={isoEmpty}/>
+      </label>
+    );
+  }
+}

--- a/packages/uxpin-merge-cli/test/resources/components/typescript/IntegrationCombo.tsx
+++ b/packages/uxpin-merge-cli/test/resources/components/typescript/IntegrationCombo.tsx
@@ -6,6 +6,7 @@ export interface ComboProps {
   arrayProp:any[];
   unionTypeArrayProp:Array<string | number>;
   booleanProp:boolean;
+  dateProp:Date;
   elementProp:React.ReactElement<any>;
   functionProp:(a:string) => number;
   stringLiteralUnion:'a' | 'b';


### PR DESCRIPTION
https://github.com/UXPin/uxpin-merge-tools/issues/226

require:
https://github.com/UXPin/uxpin-app/pull/9167

Comment about UI:
I decided to go for date.toJSON() format for flexibility what means something like that:
`2016-07-19T20:23:01.804Z`
and it have one disadvantage: its not the greatest format to edit in our UI if we want to use simplest input

Bartek said that our input from DS should probably handle that but maybe we want something different for code mode
So the question is: do we want to do something more with UI

<img width="255" alt="Zrzut ekranu 2021-03-3 o 14 45 49" src="https://user-images.githubusercontent.com/914841/109814773-2de19e00-7c2f-11eb-9ecb-c9aa8982792c.png">

