### PR TITLE
defaultValue for property with enum type

### DIFF
--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent.test.ts
@@ -67,11 +67,11 @@ describe('serializeTSComponent', () => {
             type: {
               name: 'union',
               structure: {
-                elements: expect.arrayContaining([
+                elements: [
                   { name: 'literal', structure: { value: 'secondary' } },
                   { name: 'literal', structure: { value: 'primary' } },
                   { name: 'literal', structure: { value: 'link' } },
-                ]),
+                ],
               },
             },
           },
@@ -82,11 +82,68 @@ describe('serializeTSComponent', () => {
             type: {
               name: 'union',
               structure: {
-                elements: expect.arrayContaining([
+                elements: [
                   { name: 'literal', structure: { value: 'large' } },
                   { name: 'literal', structure: { value: 'medium' } },
                   { name: 'literal', structure: { value: 'small' } },
-                ]),
+                ],
+              },
+            },
+          },
+          {
+            defaultValue:  {
+              value: 1,
+            },
+            description: '',
+            isRequired: true,
+            name: 'propNumeric',
+            type: {
+              name: 'union',
+              structure: {
+                elements:  [
+                  { name: 'literal', structure: { value: 0 } },
+                  { name: 'literal', structure: { value: 1 } },
+                ],
+              },
+            },
+          },
+          {
+            description: '',
+            isRequired: true,
+            name: 'propCustomNumeric',
+            type: {
+              name: 'union',
+              structure: {
+                elements: [
+                  { name: 'literal', structure: { value: 3 } },
+                  { name: 'literal', structure: { value: 4 } },
+                  { name: 'literal', structure: { value: 5 } },
+                ],
+              },
+            },
+          },
+          {
+            description: '',
+            isRequired: true,
+            name: 'propComputed',
+            type: {
+              name: 'unsupported',
+              structure: { raw: 'enum' } },
+          },
+          {
+            defaultValue:{
+              value: 0,
+            },
+            description: '',
+            isRequired: true,
+            name: 'propHeterogeneous',
+            type: {
+              name: 'union',
+              structure: {
+                elements: [
+                  { name: 'literal', structure: { value: 0 } },
+                  { name: 'literal', structure: { value: 'YES' } },
+                ],
               },
             },
           },

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/defaultValue/getDefaultPropertyValue.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/defaultValue/getDefaultPropertyValue.ts
@@ -18,8 +18,20 @@ export function getDefaultPropertyValue(
       return false;
     case ts.SyntaxKind.Identifier:
       return getDefaultValueFromIdentifier(context, valueInitializer as ts.Identifier);
+    case ts.SyntaxKind.PropertyAccessExpression:
+      return getDefaultValueFromPropertyAccessExpression(context, valueInitializer as ts.Identifier);
     default:
       return;
+  }
+}
+
+export function getDefaultValueFromPropertyAccessExpression(
+  context:TSSerializationContext,
+  propertyInitializer:any,
+):SupportedDefaultValue | undefined {
+  const symbol:ts.Symbol | undefined = context.checker.getSymbolAtLocation(propertyInitializer);
+  if (symbol && ts.isEnumMember(symbol.valueDeclaration) && symbol.valueDeclaration.initializer) {
+    return getDefaultPropertyValue(context, symbol.valueDeclaration.initializer);
   }
 }
 

--- a/packages/uxpin-merge-cli/test/resources/components/typescript/ClassEnumTypes.tsx
+++ b/packages/uxpin-merge-cli/test/resources/components/typescript/ClassEnumTypes.tsx
@@ -1,5 +1,32 @@
 import * as React from 'react';
 
+enum NumericEnum {
+  Zero = 0,
+  One = 1,
+}
+
+enum CustomNumericEnum {
+  Blue = 3,
+  Red,
+  Green
+}
+
+enum ComputedEnum {
+  Friday = 1,
+  Sunday = Friday * 40
+}
+
+enum BooleanLikeHeterogeneousEnum {
+  No = 0,
+  Yes = "YES",
+}
+
+enum PropSizeEnum {
+  Large = 'large',
+  Medium = 'medium',
+  Small = 'small',
+}
+
 export interface Props {
   /**
    * String only
@@ -7,24 +34,32 @@ export interface Props {
   children?:string;
   appearance:'secondary' | 'primary' | 'link';
   size?:PropSizeEnum;
+  propNumeric:NumericEnum;
+  propCustomNumeric:CustomNumericEnum;
+  propComputed:ComputedEnum;
+  propHeterogeneous:BooleanLikeHeterogeneousEnum;
 }
 
 export default class ClassEnumTypes extends React.PureComponent<Props> {
+  public static defaultProps:Partial<Props> = {
+    propNumeric:NumericEnum.One,
+    propCustomNumeric:CustomNumericEnum.Green,
+    propComputed:ComputedEnum.Sunday,
+    propHeterogeneous:BooleanLikeHeterogeneousEnum.No,
+  };
 
   public render():JSX.Element {
-    const { children, appearance } = this.props;
+    const { children, appearance, propNumeric, propCustomNumeric, propComputed, propHeterogeneous } = this.props;
     return (
       <div>
         <button className={appearance}>
           {children}
         </button>
+        <button>{propNumeric}</button>
+        <button>{propCustomNumeric}</button>
+        <button>{propComputed}</button>
+        <button>{propHeterogeneous}</button>
       </div>
     );
   }
-}
-
-enum PropSizeEnum {
-  Large = 'large',
-  Medium = 'medium',
-  Small = 'small',
 }


### PR DESCRIPTION
https://github.com/UXPin/uxpin-merge-tools/issues/203

Its long story:
I realized that new enum data type which i tried to introduce in previous week was dead end -> when i was fixing tests i found out that JS already have enum type export, its just exported as literal and all what is missing in TS is defaultValue

I added support for it but still have two flaws with enums:
<img width="217" alt="Zrzut ekranu 2021-03-10 o 14 43 18" src="https://user-images.githubusercontent.com/914841/110638539-fafb5500-81ae-11eb-92bf-7fde141cd297.png">
1. computed values are missing but i also had similar problem recently: default/computed date type is also missing. We just do not support computed stuff at all imho, its not aboutbug in single type
2. (missing) defaultValue for enum with autoincrement is more problematic. I couldnt find a way to export enum like CustomNumericEnum.Green because valueDeclaration.initializer is empty. I couldnt so far find way to hack into it

