### PR TITLE
Storybook - Support non default exported component

### DIFF
--- a/packages/uxpin-merge-cli/src/steps/building/library/__tests__/getLibraryBundleSource.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/building/library/__tests__/getLibraryBundleSource.test.ts
@@ -14,6 +14,7 @@ describe('getLibraryBundleSource', () => {
   it('returns content of library file for list of components', () => {
     const components:ComponentDefinition[] = [
       {
+        defaultExported: true,
         info: {
           dirPath: 'src/components/button',
           implementation: {
@@ -25,6 +26,7 @@ describe('getLibraryBundleSource', () => {
         ...commonProps,
       },
       {
+        defaultExported: true,
         info: {
           dirPath: 'src/components/button-list',
           implementation: {
@@ -58,6 +60,7 @@ export {
   it('returns content of library file for list of components and path of custom wrapper', () => {
     const components:ComponentDefinition[] = [
       {
+        defaultExported: true,
         info: {
           dirPath: 'src/components/button',
           implementation: {
@@ -69,6 +72,7 @@ export {
         ...commonProps,
       },
       {
+        defaultExported: true,
         info: {
           dirPath: 'src/components/button-list',
           implementation: {
@@ -106,6 +110,7 @@ export {
   it('returns content of library file for list of components including namespaced components', () => {
     const components:ComponentDefinition[] = [
       {
+        defaultExported: true,
         info: {
           dirPath: 'src/components/card',
           implementation: {
@@ -117,6 +122,7 @@ export {
         ...commonProps,
       },
       {
+        defaultExported: true,
         info: {
           dirPath: 'src/components/card/components/header',
           implementation: {
@@ -132,6 +138,7 @@ export {
         ...commonProps,
       },
       {
+        defaultExported: true,
         info: {
           dirPath: 'src/components/card/components/header/components/menu',
           implementation: {

--- a/packages/uxpin-merge-cli/src/steps/building/library/getLibraryBundleSource.ts
+++ b/packages/uxpin-merge-cli/src/steps/building/library/getLibraryBundleSource.ts
@@ -20,7 +20,7 @@ export function getLibraryBundleSource(components:ComponentDefinition[], wrapper
 
   const exports:string[] = [
     `export {`,
-    ...components.map((component) => `  ${getImportName(component)},`),
+    ...components.map((component) => `  ${getExportName(component)},`),
     ...(wrapperPath ? [`  ${CLASS_NAME_WRAPPER},`] : []),
     '  React,',
     '  ReactDOM,',
@@ -36,12 +36,16 @@ export function getLibraryBundleSource(components:ComponentDefinition[], wrapper
   ].join('\n');
 }
 
-function getImportName({ name, namespace }:ComponentDefinition):string {
-  if (namespace) {
-    return namespace.importSlug;
+function getImportName({ name, namespace, defaultExported }:ComponentDefinition):string {
+  const componentName:string = namespace ? namespace.importSlug : name;
+  if (defaultExported) {
+    return componentName;
   }
+  return `{ ${componentName} }`;
+}
 
-  return name;
+function getExportName({ name, namespace }:ComponentDefinition):string {
+  return namespace ? namespace.importSlug : name;
 }
 
 function getImportPath({ info }:ComponentDefinition):string {

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/ComponentDefinition.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/ComponentDefinition.ts
@@ -9,7 +9,7 @@ export interface ComponentMetadata {
   namespace?:ComponentNamespace;
   properties:ComponentPropertyDefinition[];
   wrappers?:ComponentWrapper[];
-  defaultExported?:boolean;
+  defaultExported:boolean;
 }
 
 export interface ComponentDefinition extends ComponentMetadata {

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/ComponentDefinition.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/ComponentDefinition.ts
@@ -9,7 +9,7 @@ export interface ComponentMetadata {
   namespace?:ComponentNamespace;
   properties:ComponentPropertyDefinition[];
   wrappers?:ComponentWrapper[];
-  defaultExported:boolean;
+  defaultExported?:boolean;
 }
 
 export interface ComponentDefinition extends ComponentMetadata {

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/ComponentDefinition.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/ComponentDefinition.ts
@@ -9,6 +9,7 @@ export interface ComponentMetadata {
   namespace?:ComponentNamespace;
   properties:ComponentPropertyDefinition[];
   wrappers?:ComponentWrapper[];
+  defaultExported?:boolean;
 }
 
 export interface ComponentDefinition extends ComponentMetadata {

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/__tests__/getComponentMetadata.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/__tests__/getComponentMetadata.test.ts
@@ -16,6 +16,7 @@ describe('getComponentMetadata – integration', () => {
         path: getTypeScriptComponentPath('IntegrationCombo'),
       };
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'IntegrationCombo',
         properties: [
           {
@@ -135,6 +136,7 @@ describe('getComponentMetadata – integration', () => {
         path: getJavaScriptComponentPath('IntegrationCombo'),
       };
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ClassWithDefaults',
         properties: [
           {

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/getSummaryResultForInvalidComponent.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/getSummaryResultForInvalidComponent.ts
@@ -12,7 +12,6 @@ export function thunkGetSummaryResultForInvalidComponent(sourcePath:string):(e:E
     };
 
     const componentMetadata:ComponentMetadata = {
-      defaultExported: false,
       name: getComponentNameFromPath(sourcePath),
       properties: [],
     };

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/getSummaryResultForInvalidComponent.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/getSummaryResultForInvalidComponent.ts
@@ -2,6 +2,7 @@ import { WarningDetails } from '../../../../common/warning/WarningDetails';
 import { ComponentMetadata } from '../ComponentDefinition';
 import { getComponentNameFromPath } from '../name/getComponentNameFromPath';
 import { ImplSerializationResult } from './ImplSerializationResult';
+import { isDefaultExported } from './javascript/isDefaultExported';
 
 export function thunkGetSummaryResultForInvalidComponent(sourcePath:string):(e:Error) => ImplSerializationResult {
   return (originalError) => {
@@ -11,7 +12,9 @@ export function thunkGetSummaryResultForInvalidComponent(sourcePath:string):(e:E
       sourcePath,
     };
 
+    const componentName:string = getComponentNameFromPath(sourcePath);
     const componentMetadata:ComponentMetadata = {
+      defaultExported: isDefaultExported(sourcePath, componentName),
       name: getComponentNameFromPath(sourcePath),
       properties: [],
     };

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/getSummaryResultForInvalidComponent.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/getSummaryResultForInvalidComponent.ts
@@ -1,4 +1,5 @@
 import { WarningDetails } from '../../../../common/warning/WarningDetails';
+import { ComponentMetadata } from '../ComponentDefinition';
 import { getComponentNameFromPath } from '../name/getComponentNameFromPath';
 import { ImplSerializationResult } from './ImplSerializationResult';
 
@@ -9,6 +10,13 @@ export function thunkGetSummaryResultForInvalidComponent(sourcePath:string):(e:E
       originalError,
       sourcePath,
     };
-    return { result: { name: getComponentNameFromPath(sourcePath), properties: [] }, warnings: [warning] };
+
+    const componentMetadata:ComponentMetadata = {
+      defaultExported: false,
+      name: getComponentNameFromPath(sourcePath),
+      properties: [],
+    };
+
+    return { result: componentMetadata, warnings: [warning] };
   };
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/__tests__/serializeJSComponent-Annotations.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/__tests__/serializeJSComponent-Annotations.test.ts
@@ -199,6 +199,7 @@ describe('SerializeJSComponent - with annotations', () => {
       return serializeJSComponent(component).then((serializedProps) => {
         // then
         const expectedMetadata:ComponentMetadata = {
+          defaultExported: true,
           name: 'ClassWithBindAnnotation',
           properties: [
             {

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/__tests__/serializeJSComponent-CustomMetadata.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/__tests__/serializeJSComponent-CustomMetadata.test.ts
@@ -11,6 +11,7 @@ describe('serializeJSComponent-CustomMetadata', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('PropTypesWithComments');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'PropTypesWithComments',
         properties: [
           {
@@ -56,6 +57,7 @@ component.`,
       // given
       const component:ComponentImplementationInfo = getImplementation('PropTypesWithCorruptedComments');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'PropTypesWithCorruptedComments',
         properties: [
           {
@@ -113,6 +115,7 @@ component.`,
       // given
       const component:ComponentImplementationInfo = getImplementation('PropTypesWithTextfieldCustomType');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'PropTypesWithTextfieldCustomType',
         properties: [
           {
@@ -256,6 +259,7 @@ component.`,
       // given
       const component:ComponentImplementationInfo = getImplementation('PropTypesWithSelectCustomType');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'PropTypesWithSelectCustomType',
         properties: [
           {

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/__tests__/serializeJSComponent.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/__tests__/serializeJSComponent.test.ts
@@ -10,6 +10,7 @@ describe('serializeJSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('FunctionPrimitivesOnly');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'FunctionPrimitivesOnly',
         properties: [
           {
@@ -52,6 +53,7 @@ describe('serializeJSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('ClassEnumTypes');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ClassEnumTypes',
         properties: [
           {
@@ -100,6 +102,7 @@ describe('serializeJSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('ClassWithDefaults');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ClassWithDefaults',
         properties: [
           {
@@ -141,6 +144,7 @@ describe('serializeJSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('ClassPropShapeType');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ClassPropShapeType',
         properties: [
           {
@@ -177,6 +181,7 @@ describe('serializeJSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('PropShapeTypeWithDefault');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'PropShapeTypeWithDefault',
         properties: [
           {
@@ -219,6 +224,7 @@ describe('serializeJSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('IntegrationComboFlow');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'IntegrationComboFlow',
         properties: [
           {
@@ -421,6 +427,7 @@ describe('serializeJSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('FunctionWithImportedEnum');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'FunctionWithImportedEnum',
         properties: [
           {
@@ -478,6 +485,7 @@ describe('serializeJSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('CorruptedDefaultPropertyValue');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'CorruptedDefaultPropertyValue',
         properties: [
           {
@@ -538,6 +546,7 @@ ReferenceError: some is not defined
       // given
       const component:ComponentImplementationInfo = getImplementation('PropTypesOneOfNumber');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'PropTypesOneOfNumber',
         properties: [
           {

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/isDefaultExported.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/isDefaultExported.ts
@@ -1,4 +1,5 @@
 import {
+  ClassDeclaration,
   ExportDefaultDeclaration,
   ExportNamedDeclaration,
   ExportSpecifier,
@@ -24,9 +25,14 @@ export function isDefaultExported(componentPath:string, name:string):boolean {
   const isNamedExported:boolean = ast.body.some((node:nodeTypes) => {
     if (node.type !== 'ExportNamedDeclaration') { return false; }
 
+    // e.g. export class Component
+    if (isClassDeclaration(node.declaration)) {
+      return node.declaration.id.name === name;
+    }
+
     // e.g. export const Component = ...
     if (isVariableDeclaration(node)) {
-      return (node.declaration as VariableDeclaration).declarations.some((variableDeclarator:VariableDeclarator) => {
+      return node.declaration.declarations.some((variableDeclarator:VariableDeclarator) => {
         return variableDeclarator.id.name === name;
       });
     }
@@ -40,6 +46,10 @@ export function isDefaultExported(componentPath:string, name:string):boolean {
   return !isNamedExported;
 }
 
-function isVariableDeclaration(node:ExportNamedDeclaration):boolean {
-  return node.declaration !== null;
+function isClassDeclaration(node:ClassDeclaration|VariableDeclaration):boolean {
+  return node.type === 'ClassDeclaration';
+}
+
+function isVariableDeclaration(node:ClassDeclaration|VariableDeclaration):boolean {
+  return node.type === 'VariableDeclaration';
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/isDefaultExported.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/isDefaultExported.ts
@@ -1,11 +1,14 @@
 import {
+  CallExpression,
   ClassDeclaration,
   ExportDefaultDeclaration,
   ExportNamedDeclaration,
   ExportSpecifier,
   FunctionDeclaration,
+  Identifier,
   ImportDeclaration,
   ModuleNode,
+  ObjectExpression,
   parse,
   VariableDeclaration,
   VariableDeclarator,
@@ -15,43 +18,60 @@ import { readFileSync } from 'fs-extra';
 // This function is checking if component is default exported by
 // checking if component is not named exported.
 // We are doing this way because there could be multiple components in a single.
-// to handle a scenario like following...
-// `ButtonDefault` is exported as default, but `ButtonSecondary` is exported as named
+// e.g.
+// `ButtonDefault` is exported as default, but `ButtonSecondary` is exported as named.
 export function isDefaultExported(componentPath:string, name:string):boolean {
   const content:string = readFileSync(componentPath, { encoding: 'utf8' });
   const ast:ModuleNode = parse(content, { sourceType: 'module', ecmaVersion: 2020 });
   if (!ast.body) { return false; }
 
   type nodeTypes = ExportDefaultDeclaration|ExportNamedDeclaration|ImportDeclaration;
-  const isNamedExported:boolean = ast.body.some((node:nodeTypes) => {
-    if (node.type !== 'ExportNamedDeclaration') { return false; }
+  let isNamedExported:boolean = false;
+  let exportDefaultDeclaration:ExportDefaultDeclaration | undefined;
+
+  ast.body.forEach((node:nodeTypes) => {
+    if (node.type === 'ExportDefaultDeclaration') {
+      exportDefaultDeclaration = node;
+    }
+
+    if (node.type !== 'ExportNamedDeclaration') { return; }
 
     // e.g. export { Component }
     if (node.declaration === null) {
       return node.specifiers.some((specifier:ExportSpecifier) => {
-        return specifier.exported.name === name;
+        isNamedExported = specifier.exported.name === name;
       });
     }
 
     // e.g. export class Component
     if (isClassDeclaration(node.declaration)) {
-      return (node.declaration as ClassDeclaration).id.name === name;
+      isNamedExported = (node.declaration as ClassDeclaration).id.name === name;
     }
 
     // e.g. export function Component
     if (isFunctionDeclaration(node.declaration)) {
-      return (node.declaration as FunctionDeclaration).id.name === name;
+      isNamedExported = (node.declaration as FunctionDeclaration).id.name === name;
     }
 
     // e.g. export const Component = ...
     if (isVariableDeclaration(node.declaration)) {
       return (node.declaration as VariableDeclaration).declarations.some((variableDeclarator:VariableDeclarator) => {
-        return variableDeclarator.id.name === name;
+        isNamedExported = variableDeclarator.id.name === name;
       });
     }
 
     return false;
   });
+
+  // e.g.
+  // /**
+  //  * @uxpincomponent
+  //  */
+  // export function Component()|class Component
+  // export default HOC(Component);
+  if (exportDefaultDeclaration && isCallExpression(exportDefaultDeclaration.declaration)) {
+    isNamedExported = !isWrappedWithHOC(name, exportDefaultDeclaration.declaration as CallExpression);
+  }
 
   return !isNamedExported;
 }
@@ -66,4 +86,24 @@ function isFunctionDeclaration(node:ClassDeclaration|VariableDeclaration|Functio
 
 function isVariableDeclaration(node:ClassDeclaration|VariableDeclaration|FunctionDeclaration):boolean {
   return node.type === 'VariableDeclaration';
+}
+
+function isCallExpression(node:ObjectExpression|Identifier|CallExpression):boolean {
+  return node.type === 'CallExpression';
+}
+
+function isWrappedWithHOC(name:string, expression?:CallExpression):boolean {
+  if (!expression) {
+    return false;
+  }
+
+  return expression.arguments && expression.arguments.some((node) => {
+    if (isCallExpression(node)) {
+      return isWrappedWithHOC(name, node as CallExpression);
+    }
+    if (node.type === 'Identifier' && node.name === name) {
+      return true;
+    }
+    return false;
+  });
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/isDefaultExported.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/isDefaultExported.ts
@@ -25,22 +25,26 @@ export function isDefaultExported(componentPath:string, name:string):boolean {
   const isNamedExported:boolean = ast.body.some((node:nodeTypes) => {
     if (node.type !== 'ExportNamedDeclaration') { return false; }
 
+    // e.g. export { Component }
+    if (node.declaration === null) {
+      return node.specifiers.some((specifier:ExportSpecifier) => {
+        return specifier.exported.name === name;
+      });
+    }
+
     // e.g. export class Component
     if (isClassDeclaration(node.declaration)) {
-      return node.declaration.id.name === name;
+      return (node.declaration as ClassDeclaration).id.name === name;
     }
 
     // e.g. export const Component = ...
-    if (isVariableDeclaration(node)) {
-      return node.declaration.declarations.some((variableDeclarator:VariableDeclarator) => {
+    if (isVariableDeclaration(node.declaration)) {
+      return (node.declaration as VariableDeclaration).declarations.some((variableDeclarator:VariableDeclarator) => {
         return variableDeclarator.id.name === name;
       });
     }
 
-    // e.g. export { Component }
-    return node.specifiers.some((specifier:ExportSpecifier) => {
-      return specifier.exported.name === name;
-    });
+    return false;
   });
 
   return !isNamedExported;

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/isDefaultExported.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/isDefaultExported.ts
@@ -3,6 +3,7 @@ import {
   ExportDefaultDeclaration,
   ExportNamedDeclaration,
   ExportSpecifier,
+  FunctionDeclaration,
   ImportDeclaration,
   ModuleNode,
   parse,
@@ -37,6 +38,11 @@ export function isDefaultExported(componentPath:string, name:string):boolean {
       return (node.declaration as ClassDeclaration).id.name === name;
     }
 
+    // e.g. export function Component
+    if (isFunctionDeclaration(node.declaration)) {
+      return (node.declaration as FunctionDeclaration).id.name === name;
+    }
+
     // e.g. export const Component = ...
     if (isVariableDeclaration(node.declaration)) {
       return (node.declaration as VariableDeclaration).declarations.some((variableDeclarator:VariableDeclarator) => {
@@ -50,10 +56,14 @@ export function isDefaultExported(componentPath:string, name:string):boolean {
   return !isNamedExported;
 }
 
-function isClassDeclaration(node:ClassDeclaration|VariableDeclaration):boolean {
+function isClassDeclaration(node:ClassDeclaration|VariableDeclaration|FunctionDeclaration):boolean {
   return node.type === 'ClassDeclaration';
 }
 
-function isVariableDeclaration(node:ClassDeclaration|VariableDeclaration):boolean {
+function isFunctionDeclaration(node:ClassDeclaration|VariableDeclaration|FunctionDeclaration):boolean {
+  return node.type === 'FunctionDeclaration';
+}
+
+function isVariableDeclaration(node:ClassDeclaration|VariableDeclaration|FunctionDeclaration):boolean {
   return node.type === 'VariableDeclaration';
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/isDefaultExported.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/isDefaultExported.ts
@@ -1,0 +1,36 @@
+import { ExportDefaultDeclaration, ExportNamedDeclaration, ExportSpecifier, ImportDeclaration, ModuleNode, parse, VariableDeclaration, VariableDeclarator } from 'acorn-loose';
+import { readFileSync } from 'fs-extra';
+
+// This function is checking if component is default exported by
+// checking if component is not named exported.
+// We are doing this way because there could be multiple components in a single.
+// to handle a scenario like following...
+// `ButtonDefault` is exported as default, but `ButtonSecondary` is exported as named
+export function isDefaultExported(componentPath:string, name:string):boolean {
+  const content:string = readFileSync(componentPath, { encoding: 'utf8' });
+  const ast:ModuleNode = parse(content, { sourceType: 'module', ecmaVersion: 2020 });
+  if (!ast.body) { return false; }
+
+  type nodeTypes = ExportDefaultDeclaration|ExportNamedDeclaration|ImportDeclaration;
+  const isNamedExported:boolean = ast.body.some((node:nodeTypes) => {
+    if (node.type !== 'ExportNamedDeclaration') { return false; }
+
+    // e.g. export const Component = ...
+    if (isVariableDeclaration(node)) {
+      return (node.declaration as VariableDeclaration).declarations.some((variableDeclarator:VariableDeclarator) => {
+        return variableDeclarator.id.name === name;
+      });
+    }
+
+    // e.g. export { Component }
+    return node.specifiers.some((specifier:ExportSpecifier) => {
+      return specifier.exported.name === name;
+    });
+  });
+
+  return !isNamedExported;
+}
+
+function isVariableDeclaration(node:ExportNamedDeclaration):boolean {
+  return node.declaration !== null;
+}

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/isDefaultExported.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/isDefaultExported.ts
@@ -1,4 +1,13 @@
-import { ExportDefaultDeclaration, ExportNamedDeclaration, ExportSpecifier, ImportDeclaration, ModuleNode, parse, VariableDeclaration, VariableDeclarator } from 'acorn-loose';
+import {
+  ExportDefaultDeclaration,
+  ExportNamedDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ModuleNode,
+  parse,
+  VariableDeclaration,
+  VariableDeclarator,
+} from 'acorn-loose';
 import { readFileSync } from 'fs-extra';
 
 // This function is checking if component is default exported by

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/isDefaultExported.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/isDefaultExported.ts
@@ -32,35 +32,39 @@ export function isDefaultExported(componentPath:string, name:string):boolean {
   ast.body.forEach((node:nodeTypes) => {
     if (node.type === 'ExportDefaultDeclaration') {
       exportDefaultDeclaration = node;
+      return;
     }
 
     if (node.type !== 'ExportNamedDeclaration') { return; }
 
     // e.g. export { Component }
     if (node.declaration === null) {
-      return node.specifiers.some((specifier:ExportSpecifier) => {
-        isNamedExported = specifier.exported.name === name;
+      isNamedExported = node.specifiers.some((specifier:ExportSpecifier) => {
+        return specifier.exported.name === name;
       });
+      return;
     }
 
     // e.g. export class Component
     if (isClassDeclaration(node.declaration)) {
       isNamedExported = (node.declaration as ClassDeclaration).id.name === name;
+      return;
     }
 
     // e.g. export function Component
     if (isFunctionDeclaration(node.declaration)) {
       isNamedExported = (node.declaration as FunctionDeclaration).id.name === name;
+      return;
     }
 
     // e.g. export const Component = ...
     if (isVariableDeclaration(node.declaration)) {
-      return (node.declaration as VariableDeclaration).declarations.some((variableDeclarator:VariableDeclarator) => {
-        isNamedExported = variableDeclarator.id.name === name;
-      });
+      isNamedExported = (node.declaration as VariableDeclaration).declarations.some(
+        (variableDeclarator:VariableDeclarator) => {
+          return variableDeclarator.id.name === name;
+        });
+      return;
     }
-
-    return false;
   });
 
   // e.g.

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/serializeJSComponent.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/serializeJSComponent.ts
@@ -17,6 +17,7 @@ import { PropDefinitionSerializationResult } from '../PropDefinitionSerializatio
 import { getComponentName } from './getComponentName';
 import { getComponentNamespaceFromDescription } from './getComponentNamespaceFromDescription';
 import { getDefaultComponentFrom } from './getDefaultComponentFrom';
+import { isDefaultExported } from './isDefaultExported';
 import { parsePropertyItem } from './parsePropertyItem';
 
 export function serializeJSComponent(component:ComponentImplementationInfo):Promise<ImplSerializationResult> {
@@ -30,8 +31,10 @@ function thunkGetMetadata(implInfo:ComponentImplementationInfo):(parsed:Componen
     const properties:PropDefinitionSerializationResult[] = await getComponentProperties(parsed.props);
     const name:string = getComponentName(implInfo.path, parsed);
     const wrappers:Warned<ComponentWrapper[]> = getComponentWrappers(parsed, implInfo);
+    const defaultExported:boolean = isDefaultExported(implInfo.path, name);
 
     return {
+      defaultExported,
       name,
       properties,
       wrappers,
@@ -99,4 +102,5 @@ interface PartialResult {
   namespace?:ComponentNamespace;
   properties:PropDefinitionSerializationResult[];
   wrappers:Warned<ComponentWrapper[]>;
+  defaultExported:boolean;
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent-Annotations.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent-Annotations.test.ts
@@ -13,7 +13,7 @@ describe('serializeTSComponent-Annotations', () => {
       return serializeTSComponent(component).then((serializedProps) => {
         // then
         const expectedMetadata:ComponentMetadata = {
-          defaultExported: true,
+          defaultExported: false,
           name: 'FunctionWithBindAnnotation',
           properties: [
             {

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent-Annotations.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent-Annotations.test.ts
@@ -13,6 +13,7 @@ describe('serializeTSComponent-Annotations', () => {
       return serializeTSComponent(component).then((serializedProps) => {
         // then
         const expectedMetadata:ComponentMetadata = {
+          defaultExported: true,
           name: 'FunctionWithBindAnnotation',
           properties: [
             {

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent-Namespaces.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent-Namespaces.test.ts
@@ -10,6 +10,7 @@ describe('serializeTSComponent-Namespaces', () => {
       // having
       const component:ComponentImplementationInfo = getImplementation('ClassWithNamespaceDeclaration');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ClassWithNamespaceDeclaration',
         namespace: {
           importSlug: 'Namespace_ClassWithNamespaceDeclaration',
@@ -38,6 +39,7 @@ describe('serializeTSComponent-Namespaces', () => {
       // having
       const component:ComponentImplementationInfo = getImplementation('ClassWithMultilevelNamespaceDeclaration');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ClassWithMultilevelNamespaceDeclaration',
         namespace: {
           importSlug: 'Some_Nested_Namespace_ClassWithMultilevelNamespaceDeclaration',
@@ -68,6 +70,7 @@ describe('serializeTSComponent-Namespaces', () => {
       // having
       const component:ComponentImplementationInfo = getImplementation('FunctionWithNamespaceDeclaration');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'FunctionWithNamespaceDeclaration',
         namespace: {
           importSlug: 'Namespace_FunctionWithNamespaceDeclaration',
@@ -96,6 +99,7 @@ describe('serializeTSComponent-Namespaces', () => {
       // having
       const component:ComponentImplementationInfo = getImplementation('FunctionWithMultilevelNamespaceDeclaration');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'FunctionWithMultilevelNamespaceDeclaration',
         namespace: {
           importSlug: 'Some_Nested_Namespace_FunctionWithMultilevelNamespaceDeclaration',

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent-Wrappers.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent-Wrappers.test.ts
@@ -18,6 +18,7 @@ describe('serializeTSComponent-Wrappers', () => {
     it('serializes metadata correctly', () => {
       // having
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ClassWithWrappersDeclaration',
         properties: [
           {
@@ -61,6 +62,7 @@ describe('serializeTSComponent-Wrappers', () => {
     it('serializes metadata correctly', () => {
       // having
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ClassWithWrappersDeclaration',
         properties: [
           {

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent.test.ts
@@ -10,6 +10,7 @@ describe('serializeTSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('FunctionPrimitivesOnly');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'FunctionPrimitivesOnly',
         properties: [
           {
@@ -52,6 +53,7 @@ describe('serializeTSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('ClassEnumTypes');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ClassEnumTypes',
         properties: [
           {
@@ -106,6 +108,7 @@ describe('serializeTSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('ClassWithDefaults');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ClassWithDefaults',
         properties: [
           {
@@ -196,6 +199,7 @@ describe('serializeTSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('ClassInterfaceTypes');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ClassInterfaceTypes',
         properties: [
           {
@@ -220,6 +224,7 @@ describe('serializeTSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('FunctionWithImportedTypes');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'FunctionWithImportedTypes',
         properties: [
           {
@@ -250,6 +255,7 @@ describe('serializeTSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('ClassWithImportedPropertiesType');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ClassWithImportedPropertiesType',
         properties: [
           {
@@ -286,6 +292,7 @@ describe('serializeTSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('ClassWithFunctionTypes');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ClassWithFunctionTypes',
         properties: [
           {
@@ -334,6 +341,7 @@ describe('serializeTSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('ClassWithCombinedPropertiesType');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ClassWithCombinedPropertiesType',
         properties: [
           {
@@ -376,6 +384,7 @@ describe('serializeTSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('FunctionWithExtendedPropertiesType');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'FunctionWithExtendedPropertiesType',
         properties: [
           {
@@ -419,6 +428,7 @@ describe('serializeTSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('ArrowFunctionWithDefaultsAsStaticProperty');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ArrowFunctionWithDefaultsAsStaticProperty',
         properties: [
           {
@@ -470,6 +480,7 @@ describe('serializeTSComponent', () => {
       const component:ComponentImplementationInfo =
         getImplementation('DefaultExportedArrowFunctionWithDefaultsInDestructuring');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'DefaultExportedArrowFunctionWithDefaultsInDestructuring',
         properties: [
           {
@@ -508,6 +519,7 @@ describe('serializeTSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('FunctionWithDefaultsInDestructuring');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'FunctionWithDefaultsInDestructuring',
         properties: [
           {
@@ -558,6 +570,7 @@ describe('serializeTSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('ClassWithIndexedType');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ClassWithIndexedType',
         properties: [
           {
@@ -594,6 +607,7 @@ describe('serializeTSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('ClassWithExtendedInterface');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ClassWithExtendedInterface',
         properties: [
           {
@@ -648,6 +662,7 @@ describe('serializeTSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('FunctionWithCombinedPropertiesType');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'FunctionWithCombinedPropertiesType',
         properties: [
           {
@@ -702,6 +717,7 @@ describe('serializeTSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('FunctionWithCombinedUnionPropertiesType');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'FunctionWithCombinedUnionPropertiesType',
         properties: [
           {
@@ -750,6 +766,7 @@ describe('serializeTSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('FunctionWithCombinedProperty');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'FunctionWithCombinedProperty',
         properties: [
           {
@@ -782,6 +799,7 @@ describe('serializeTSComponent', () => {
       const component:ComponentImplementationInfo =
         getImplementation('ClassWithTypeImportedFromIndexFileExportingFromImport');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ClassWithTypeImportedFromIndexFileExportingFromImport',
         properties: [
           {
@@ -809,6 +827,7 @@ describe('serializeTSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('ClassWithUnionTypeInAliasType');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ClassWithUnionTypeInAliasType',
         properties: [
           {
@@ -859,6 +878,7 @@ describe('serializeTSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('ClassWithKeyOfTypeOfOperatorInType');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ClassWithKeyOfTypeOfOperatorInType',
         properties: [
           {
@@ -911,6 +931,7 @@ describe('serializeTSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('ClassWithArrayOfUnionType');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ClassWithArrayOfUnionType',
         properties: [
           {
@@ -944,6 +965,7 @@ describe('serializeTSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('ClassWithTwoDimensionalArray');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ClassWithTwoDimensionalArray',
         properties: [
           {
@@ -1001,6 +1023,7 @@ describe('serializeTSComponent', () => {
     describe('file with default exported component composed with HOC is given', () => {
       const getI18nComponentMetadata:(expectedName:string) => ComponentMetadata = (expectedName:string) => {
         return {
+          defaultExported: true,
           name: expectedName,
           properties: [
             {
@@ -1106,6 +1129,7 @@ describe('serializeTSComponent', () => {
       // given
       const component:ComponentImplementationInfo = getImplementation('ClassWithPropTypesWithComments');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ClassWithPropTypesWithComments',
         properties: [
           {
@@ -1162,6 +1186,7 @@ component.`,
       // given
       const component:ComponentImplementationInfo = getImplementation('ClassWithCorruptedComments');
       const expectedMetadata:ComponentMetadata = {
+        defaultExported: true,
         name: 'ClassWithCorruptedComments',
         properties: [
           {

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/findDefaultExportedClass.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/findDefaultExportedClass.ts
@@ -1,11 +1,12 @@
 import * as ts from 'typescript';
+import { TSSerializationContext } from '../context/getSerializationContext';
 import { ClassComponentDeclaration } from './getPropsTypeAndDefaultProps';
 import { isDefaultExported } from './isDefaultExported';
 
-export function findDefaultExportedClass(sourceFile:ts.SourceFile):ClassComponentDeclaration | undefined {
+export function findDefaultExportedClass(context:TSSerializationContext):ClassComponentDeclaration | undefined {
   let result:ts.ClassDeclaration | ts.ClassExpression | undefined;
-  ts.forEachChild(sourceFile, (node) => {
-    if ((ts.isClassDeclaration(node) || ts.isClassExpression(node)) && isDefaultExported(node)) {
+  ts.forEachChild(context.file, (node) => {
+    if ((ts.isClassDeclaration(node) || ts.isClassExpression(node)) && isDefaultExported(node, context)) {
       result = node;
     }
   });

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/findDefaultExportedFunction.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/findDefaultExportedFunction.ts
@@ -1,10 +1,11 @@
 import * as ts from 'typescript';
+import { TSSerializationContext } from '../context/getSerializationContext';
 import { isDefaultExported } from './isDefaultExported';
 
-export function findDefaultExportedFunction(sourceFile:ts.SourceFile):ts.FunctionDeclaration | undefined {
+export function findDefaultExportedFunction(context:TSSerializationContext):ts.FunctionDeclaration | undefined {
   let result:ts.FunctionDeclaration | undefined;
-  ts.forEachChild(sourceFile, (node) => {
-    if (ts.isFunctionDeclaration(node) && isDefaultExported(node)) {
+  ts.forEachChild(context.file, (node) => {
+    if (ts.isFunctionDeclaration(node) && isDefaultExported(node, context)) {
       result = node;
     }
   });

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/findExportedArrowFunctionWithName.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/findExportedArrowFunctionWithName.ts
@@ -1,0 +1,24 @@
+import * as ts from 'typescript';
+import { getNodeName } from '../node/getNodeName';
+import { isExported } from './isExported';
+
+export function findExportedArrowFunctionWithName(
+  sourceFile:ts.SourceFile, componentFileName:string):ts.ArrowFunction | undefined {
+
+  let result:ts.ArrowFunction | undefined;
+  ts.forEachChild(sourceFile, (node) => {
+    // Named Arrow Function:
+    //     export const Foo = () => {};
+    if (
+        ts.isVariableStatement(node) &&
+        isExported(node) &&
+        node.declarationList.declarations[0].initializer &&
+        ts.isArrowFunction(node.declarationList.declarations[0].initializer) &&
+        getNodeName(node.declarationList.declarations[0]) === componentFileName
+      ) {
+      result = node.declarationList.declarations[0].initializer;
+      return;
+    }
+  });
+  return result;
+}

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/findExportedArrowFunctionWithName.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/findExportedArrowFunctionWithName.ts
@@ -1,12 +1,13 @@
 import * as ts from 'typescript';
+import { TSSerializationContext } from '../context/getSerializationContext';
 import { getNodeName } from '../node/getNodeName';
 import { isExported } from './isExported';
 
 export function findExportedArrowFunctionWithName(
-  sourceFile:ts.SourceFile, componentFileName:string):ts.ArrowFunction | undefined {
+  context:TSSerializationContext, componentFileName:string):ts.ArrowFunction | undefined {
 
   let result:ts.ArrowFunction | undefined;
-  ts.forEachChild(sourceFile, (node) => {
+  ts.forEachChild(context.file, (node) => {
     // Named Arrow Function:
     //     export const Foo = () => {};
     if (

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/findExportedClassWithName.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/findExportedClassWithName.ts
@@ -1,14 +1,15 @@
 import * as ts from 'typescript';
+import { TSSerializationContext } from '../context/getSerializationContext';
 import { getNodeName } from '../node/getNodeName';
 import { ClassComponentDeclaration } from './getPropsTypeAndDefaultProps';
 import { isExported } from './isExported';
 
 export function findExportedClassWithName(
-  sourceFile:ts.SourceFile,
+  context:TSSerializationContext,
   className:string,
 ):ClassComponentDeclaration | undefined {
   let result:ts.ClassDeclaration | ts.ClassExpression | undefined;
-  ts.forEachChild(sourceFile, (node) => {
+  ts.forEachChild(context.file, (node) => {
     if (ts.isClassDeclaration(node) && isExported(node) && getNodeName(node) === className) {
       result = node;
     }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/findExportedFunctionWithName.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/findExportedFunctionWithName.ts
@@ -1,13 +1,14 @@
 import * as ts from 'typescript';
+import { TSSerializationContext } from '../context/getSerializationContext';
 import { getNodeName } from '../node/getNodeName';
 import { isExported } from './isExported';
 
 export function findExportedFunctionWithName(
-  sourceFile:ts.SourceFile,
+  context:TSSerializationContext,
   functionName:string,
 ):ts.FunctionDeclaration | undefined {
   let result:ts.FunctionDeclaration | undefined;
-  ts.forEachChild(sourceFile, (node) => {
+  ts.forEachChild(context.file, (node) => {
     if (ts.isFunctionDeclaration(node) && isExported(node) && getNodeName(node) === functionName) {
       result = node;
     }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/findSpecifiedComponent.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/findSpecifiedComponent.ts
@@ -1,5 +1,6 @@
 import * as ts from 'typescript';
 import { hasUXPinComponentComment } from '../comments/hasUXPinComponentComment';
+import { TSSerializationContext } from '../context/getSerializationContext';
 import {
   ClassComponentDeclaration,
   ComponentDeclaration,
@@ -8,19 +9,19 @@ import {
 import { isClassComponentDeclaration } from './isClassComponentDeclaration';
 import { isFunctionalComponentDeclaration } from './isFunctionalComponentDeclaration';
 
-export const findSpecifiedClassComponent:(sourceFile:ts.SourceFile) => ClassComponentDeclaration | undefined =
+export const findSpecifiedClassComponent:(context:TSSerializationContext) => ClassComponentDeclaration | undefined =
   createFindSpecifiedComponent(isClassComponentDeclaration);
 
-export const findSpecifiedFunctionComponent:(sourceFile:ts.SourceFile) => FunctionalComponentDeclaration | undefined =
-  createFindSpecifiedComponent(isFunctionalComponentDeclaration);
+export const findSpecifiedFunctionComponent:(context:TSSerializationContext) =>
+  FunctionalComponentDeclaration | undefined = createFindSpecifiedComponent(isFunctionalComponentDeclaration);
 
 function createFindSpecifiedComponent<T extends ComponentDeclaration>(
   declarationChecker:(node:ts.Node) => node is T,
-):(sourceFile:ts.SourceFile) => T | undefined {
-  return (sourceFile:ts.SourceFile) => {
+):(context:TSSerializationContext) => T | undefined {
+  return (context:TSSerializationContext) => {
     let result:T | undefined;
 
-    ts.forEachChild(sourceFile, (node) => {
+    ts.forEachChild(context.file, (node) => {
       if (!result && declarationChecker(node) && hasUXPinComponentComment(node)) {
         result = node;
       }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/getComponentDeclaration.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/getComponentDeclaration.ts
@@ -20,26 +20,26 @@ import {
 export function getComponentDeclaration(context:TSSerializationContext):ComponentDeclaration | undefined {
   const fileName:string = getComponentFileName(context);
 
-  return findFunctionalComponent(context.file, fileName)
-    || findClassComponent(context.file, fileName);
+  return findFunctionalComponent(context, fileName)
+    || findClassComponent(context, fileName);
 }
 
 function findFunctionalComponent(
-  sourceFile:ts.SourceFile,
+  context:TSSerializationContext,
   componentFileName:string,
 ):FunctionalComponentDeclaration | undefined {
-  return findSpecifiedFunctionComponent(sourceFile)
-    || findDefaultExportedFunction(sourceFile)
-    || findExportedFunctionWithName(sourceFile, componentFileName)
-    || findDefaultExportedArrowFunction(sourceFile)
-    || findExportedArrowFunctionWithName(sourceFile, componentFileName);
+  return findSpecifiedFunctionComponent(context)
+    || findDefaultExportedFunction(context)
+    || findExportedFunctionWithName(context, componentFileName)
+    || findDefaultExportedArrowFunction(context)
+    || findExportedArrowFunctionWithName(context, componentFileName);
 }
 
 function findClassComponent(
-  sourceFile:ts.SourceFile,
+  context:TSSerializationContext,
   componentFileName:string,
 ):ClassComponentDeclaration | undefined {
-  return findSpecifiedClassComponent(sourceFile)
-    || findDefaultExportedClass(sourceFile)
-    || findExportedClassWithName(sourceFile, componentFileName);
+  return findSpecifiedClassComponent(context)
+    || findDefaultExportedClass(context)
+    || findExportedClassWithName(context, componentFileName);
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/getComponentDeclaration.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/getComponentDeclaration.ts
@@ -1,4 +1,3 @@
-import * as ts from 'typescript';
 import { TSSerializationContext } from '../context/getSerializationContext';
 import { findDefaultExportedArrowFunction } from './findDefaultExportedArrowFunction';
 import { findDefaultExportedClass } from './findDefaultExportedClass';

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/getComponentDeclaration.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/getComponentDeclaration.ts
@@ -3,6 +3,7 @@ import { TSSerializationContext } from '../context/getSerializationContext';
 import { findDefaultExportedArrowFunction } from './findDefaultExportedArrowFunction';
 import { findDefaultExportedClass } from './findDefaultExportedClass';
 import { findDefaultExportedFunction } from './findDefaultExportedFunction';
+import { findExportedArrowFunctionWithName } from './findExportedArrowFunctionWithName';
 import { findExportedClassWithName } from './findExportedClassWithName';
 import { findExportedFunctionWithName } from './findExportedFunctionWithName';
 import {
@@ -30,7 +31,8 @@ function findFunctionalComponent(
   return findSpecifiedFunctionComponent(sourceFile)
     || findDefaultExportedFunction(sourceFile)
     || findExportedFunctionWithName(sourceFile, componentFileName)
-    || findDefaultExportedArrowFunction(sourceFile);
+    || findDefaultExportedArrowFunction(sourceFile)
+    || findExportedArrowFunctionWithName(sourceFile, componentFileName);
 }
 
 function findClassComponent(

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/getPropsTypeAndDefaultProps.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/getPropsTypeAndDefaultProps.ts
@@ -18,8 +18,9 @@ export interface ComponentDeclarationData {
 
 export type ClassComponentDeclaration = ts.ClassDeclaration | ts.ClassExpression;
 export type FunctionalComponentDeclaration = ts.FunctionDeclaration | ts.ArrowFunction;
+export type VariableDeclaration = ts.VariableDeclaration;
 
-export type ComponentDeclaration = FunctionalComponentDeclaration | ClassComponentDeclaration;
+export type ComponentDeclaration = FunctionalComponentDeclaration | ClassComponentDeclaration | VariableDeclaration;
 
 export function getPropsTypeAndDefaultProps(
   context:TSSerializationContext,

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/isDefaultExported.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/isDefaultExported.ts
@@ -1,11 +1,103 @@
 import * as ts from 'typescript';
+import { hasUXPinComponentComment } from '../comments/hasUXPinComponentComment';
+import { TSSerializationContext } from '../context/getSerializationContext';
+import { getNodeName } from '../node/getNodeName';
+import { getComponentName } from './getComponentName';
 import { ComponentDeclaration } from './getPropsTypeAndDefaultProps';
 import { isExported } from './isExported';
 
-export function isDefaultExported(node:ComponentDeclaration):boolean {
-  if (!node.modifiers) {
+export function isDefaultExported(declaration:ComponentDeclaration, context:TSSerializationContext):boolean {
+  const componentName:string = getComponentName(context, declaration);
+
+  // e.g. export default () => {};
+  if (ts.isArrowFunction(declaration) && ts.isExportAssignment(declaration.parent)) {
+    return true;
+  }
+
+  // e.g. export default Class Component
+  // e.g. export default function Component()
+  // NOTE: This returns `false` for cases like below. So, it is too early to tell
+  // if this file export Component as default or not.
+  // And it will be checked with `isWrappedWithHOC` at later steps
+  // ------------------- Case #1
+  // /**
+  //  * @uxpincomponent
+  //  */
+  // export class Button
+  // export default withHOC(Component)
+  // ------------------- Case #2
+  // export function FunctionMatchWithFileName()| export class ClassMatchWithFileName
+  // export default withHOC(FunctionMatchWithFileName|ClassMatchWithFileName)
+  if (!hasUXPinComponentComment(declaration) && hasDefaultKeywordInModifiers(declaration)) {
+    return true;
+  }
+
+  // export default Component;
+  // Because export statement is in different node, we need to go through again...
+  let isDefault:boolean = false;
+  ts.forEachChild(context.file, (node) => {
+    if (!ts.isExportAssignment(node)) { return; }
+
+    const exportedName:string = (node.expression as any).escapedText;
+
+    // const Component = () => {}
+    if (isDefaultExportedArrowFunctionWithName(exportedName, componentName, declaration)) {
+      isDefault = true;
+    }
+
+    // function Component()
+    if (isDefaultExportedFunctionWithName(exportedName, declaration)) {
+      isDefault = true;
+    }
+
+    // class Component
+    if (isDefaultExportedClassWithName(exportedName, declaration)) {
+      isDefault = true;
+    }
+
+    // component wrapped with HOC.
+    // export default withHOC(Component);
+    if (declaration.name && isWrappedWithHOC(componentName, node.expression)) {
+      isDefault = true;
+    }
+  });
+  return isDefault;
+}
+
+function isDefaultExportedArrowFunctionWithName(
+    exportedName:string,
+    componentName:string,
+    declaration:ComponentDeclaration):boolean {
+
+  return ts.isArrowFunction(declaration) && exportedName === componentName;
+}
+
+function isDefaultExportedFunctionWithName(exportedName:string, declaration:ComponentDeclaration):boolean {
+  return ts.isFunctionDeclaration(declaration) && exportedName === getNodeName(declaration);
+}
+
+function isDefaultExportedClassWithName(exportedName:string, declaration:ComponentDeclaration):boolean {
+  return ts.isFunctionDeclaration(declaration) && exportedName === getNodeName(declaration);
+}
+
+function isWrappedWithHOC(exportedName:string, expression?:ts.Expression):boolean {
+  if (!expression) {
     return false;
   }
-  const isDefault:boolean = node.modifiers.some((m) => m.kind === ts.SyntaxKind.DefaultKeyword);
-  return isExported(node) && isDefault;
+
+  // @ts-ignore
+  return expression.arguments && expression.arguments.some((node) => {
+    if (node.escapedText === exportedName) {
+      return true;
+    }
+    return isWrappedWithHOC(exportedName, node.expression);
+  });
+}
+
+function hasDefaultKeywordInModifiers(declaration:ComponentDeclaration):boolean {
+  return (
+    !!declaration.modifiers &&
+    isExported(declaration) &&
+    declaration.modifiers.some((m) => m.kind === ts.SyntaxKind.DefaultKeyword)
+  );
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/isExported.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/isExported.ts
@@ -1,7 +1,7 @@
 import * as ts from 'typescript';
 import { ComponentDeclaration } from './getPropsTypeAndDefaultProps';
 
-export function isExported(node:ComponentDeclaration):boolean {
+export function isExported(node:ComponentDeclaration | ts.VariableStatement):boolean {
   if (!node.modifiers) {
     return false;
   }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/node/getNodeName.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/node/getNodeName.ts
@@ -1,6 +1,6 @@
 import * as ts from 'typescript';
 
-export function getNodeName(node:{ name?:ts.Identifier | ts.PropertyName }):ts.__String | undefined {
+export function getNodeName(node:{ name?:ts.Identifier | ts.PropertyName | ts.BindingName }):ts.__String | undefined {
   if (node.name && ts.isIdentifier(node.name)) {
     return node.name.escapedText;
   }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/serializeTSComponent.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/serializeTSComponent.ts
@@ -13,6 +13,7 @@ import { getComponentName } from './component/getComponentName';
 import { getComponentNamespace } from './component/getComponentNamespace';
 import { getComponentWrappers } from './component/getComponentWrappers';
 import { ComponentDeclaration } from './component/getPropsTypeAndDefaultProps';
+import { isDefaultExported } from './component/isDefaultExported';
 import { getSerializationContext, TSSerializationContext } from './context/getSerializationContext';
 import { parseTSComponentProperties } from './parseTSComponentProperties';
 
@@ -30,9 +31,11 @@ export async function serializeTSComponent(component:ComponentImplementationInfo
   const namespace:ComponentNamespace | undefined = getComponentNamespace(declaration, name);
   const wrappers:ComponentWrapper[] = getComponentWrappers(declaration);
   const validatedWrappers:Warned<ComponentWrapper[]> = validateWrappers(wrappers, component);
+  const defaultExported:boolean = isDefaultExported(declaration);
 
   return {
     result: {
+      defaultExported,
       name,
       namespace,
       properties: validatedProps.map(({ result }) => result),

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/serializeTSComponent.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/serializeTSComponent.ts
@@ -31,7 +31,7 @@ export async function serializeTSComponent(component:ComponentImplementationInfo
   const namespace:ComponentNamespace | undefined = getComponentNamespace(declaration, name);
   const wrappers:ComponentWrapper[] = getComponentWrappers(declaration);
   const validatedWrappers:Warned<ComponentWrapper[]> = validateWrappers(wrappers, component);
-  const defaultExported:boolean = isDefaultExported(declaration);
+  const defaultExported:boolean = isDefaultExported(declaration, context);
 
   return {
     result: {

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/name/__tests__/getComponentNamespacedName.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/name/__tests__/getComponentNamespacedName.test.ts
@@ -5,6 +5,7 @@ describe('getComponentNamespacedName', () => {
   it('should get valid name for component without namespace', () => {
     // having
     const metadata:ComponentMetadata = {
+      defaultExported: true,
       name: 'Button',
       properties: [],
     };
@@ -17,6 +18,7 @@ describe('getComponentNamespacedName', () => {
   it('should get valid name for component with namespace', () => {
     // having
     const metadata:ComponentMetadata = {
+      defaultExported: true,
       name: 'Button',
       namespace: {
         importSlug: 'Card_Header_Button',

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/presets/jsx/bundle/__tests__/getSourceFileContentToBundle.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/presets/jsx/bundle/__tests__/getSourceFileContentToBundle.test.ts
@@ -6,6 +6,7 @@ describe('getSourceFileContentToBundle', () => {
     // given
     const components:ComponentDefinition[] = [
       {
+        defaultExported: true,
         documentation: { examples: [] },
         info: {
           dirPath: '',
@@ -20,6 +21,7 @@ describe('getSourceFileContentToBundle', () => {
         properties: [],
       },
       {
+        defaultExported: true,
         documentation: { examples: [] },
         info: {
           dirPath: '',

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/presets/jsx/compile/__tests__/generateVirtualModules.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/presets/jsx/compile/__tests__/generateVirtualModules.test.ts
@@ -5,6 +5,7 @@ describe('generateVirtualModules', () => {
   it('generates virtual module objects for component definitions', () => {
     const components:ComponentDefinition[] = [
       {
+        defaultExported: true,
         documentation: { examples: [] },
         info: {
           dirPath: 'src/components/Avatar',
@@ -21,6 +22,7 @@ describe('generateVirtualModules', () => {
         properties: [],
       },
       {
+        defaultExported: true,
         documentation: { examples: [] },
         info: {
           dirPath: 'src/packages/navigation/Menu',
@@ -63,6 +65,7 @@ exports.default = {"name":"Menu"};`,
   it('generates virtual module objects for namespaced component definitions', () => {
     const components:ComponentDefinition[] = [
       {
+        defaultExported: true,
         documentation: { examples: [] },
         info: {
           dirPath: 'src/components/Button',
@@ -79,6 +82,7 @@ exports.default = {"name":"Menu"};`,
         properties: [],
       },
       {
+        defaultExported: true,
         documentation: { examples: [] },
         info: {
           dirPath: 'src/components/Card',
@@ -95,6 +99,7 @@ exports.default = {"name":"Menu"};`,
         properties: [],
       },
       {
+        defaultExported: true,
         documentation: { examples: [] },
         info: {
           dirPath: 'src/components/Card/components/Body',
@@ -115,6 +120,7 @@ exports.default = {"name":"Menu"};`,
         properties: [],
       },
       {
+        defaultExported: true,
         documentation: { examples: [] },
         info: {
           dirPath: 'src/components/Card/components/Header',
@@ -135,6 +141,7 @@ exports.default = {"name":"Menu"};`,
         properties: [],
       },
       {
+        defaultExported: true,
         documentation: { examples: [] },
         info: {
           dirPath: 'src/components/Card/components/Header/components/Menu',

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/presets/jsx/compile/__tests__/getNamespacedComponentsTree.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/presets/jsx/compile/__tests__/getNamespacedComponentsTree.test.ts
@@ -4,6 +4,7 @@ import { getNamespacedComponentsTree, NamespacedComponentsTree } from '../getNam
 describe('getNamespacedComponentsTree', () => {
   const components:ComponentDefinition[] = [
     {
+      defaultExported: true,
       documentation: { examples: [] },
       info: {
         dirPath: 'src/components/Button',
@@ -20,6 +21,7 @@ describe('getNamespacedComponentsTree', () => {
       properties: [],
     },
     {
+      defaultExported: true,
       documentation: { examples: [] },
       info: {
         dirPath: 'src/components/Card',
@@ -36,6 +38,7 @@ describe('getNamespacedComponentsTree', () => {
       properties: [],
     },
     {
+      defaultExported: true,
       documentation: { examples: [] },
       info: {
         dirPath: 'src/components/Card/components/Body',
@@ -56,6 +59,7 @@ describe('getNamespacedComponentsTree', () => {
       properties: [],
     },
     {
+      defaultExported: true,
       documentation: { examples: [] },
       info: {
         dirPath: 'src/components/Card/components/Header',
@@ -76,6 +80,7 @@ describe('getNamespacedComponentsTree', () => {
       properties: [],
     },
     {
+      defaultExported: true,
       documentation: { examples: [] },
       info: {
         dirPath: 'src/components/Card/components/Header/components/Menu',

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/presets/jsx/compile/generateVirtualModules.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/presets/jsx/compile/generateVirtualModules.ts
@@ -20,10 +20,12 @@ export function generateVirtualModules(components:ComponentDefinition[]):Virtual
 }
 
 function createVirtualModule(component:ComponentDefinition, tree:NamespacedComponentsTree):VirtualComponentModule {
+  const exportName:string = component.defaultExported ? 'default' : component.name;
+
   return ({
     moduleSource: `
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.default = ${JSON.stringify(createComponentPlaceholder(component, tree))};`,
+exports.${exportName} = ${JSON.stringify(createComponentPlaceholder(component, tree))};`,
     path: removeExtensionFromPath(component.info.implementation.path),
   });
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/vcs/__tests__/filterMovedFiles.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/vcs/__tests__/filterMovedFiles.test.ts
@@ -23,6 +23,7 @@ describe('filterMovedFiles', () => {
       {
         components: [
           {
+            defaultExported: true,
             documentation: { examples: [] },
             info: {
               dirPath: 'src/NewFoo',
@@ -42,6 +43,7 @@ describe('filterMovedFiles', () => {
       {
         components: [
           {
+            defaultExported: true,
             documentation: { examples: [] },
             info: {
               dirPath: 'src/NewBar',

--- a/packages/uxpin-merge-cli/src/types/acorn-loose.d.ts
+++ b/packages/uxpin-merge-cli/src/types/acorn-loose.d.ts
@@ -15,7 +15,7 @@ export interface ExportDefaultDeclaration extends Node {
 
 export interface ExportNamedDeclaration extends Node {
   type:'ExportNamedDeclaration';
-  declaration: VariableDeclaration|null;
+  declaration: ClassDeclaration|VariableDeclaration|null;
   specifiers: ExportSpecifier[];
 }
 
@@ -68,6 +68,11 @@ export interface Literal extends Node {
   value:string;
 }
 
+export interface ClassDeclaration extends Node {
+  type:'ClassDeclaration';
+  id:Identifier;
+}
+
 export interface VariableDeclaration extends Node {
   type:'VariableDeclaration';
   declarations:VariableDeclarator[];
@@ -75,10 +80,5 @@ export interface VariableDeclaration extends Node {
 
 export interface VariableDeclarator extends Node {
   type:'VariableDeclarator';
-  id:Identifier;
-}
-
-export interface ClassDeclaration extends Node {
-  type:'ClassDeclaration';
   id:Identifier;
 }

--- a/packages/uxpin-merge-cli/src/types/acorn-loose.d.ts
+++ b/packages/uxpin-merge-cli/src/types/acorn-loose.d.ts
@@ -77,3 +77,8 @@ export interface VariableDeclarator extends Node {
   type:'VariableDeclarator';
   id:Identifier;
 }
+
+export interface ClassDeclaration extends Node {
+  type:'ClassDeclaration';
+  id:Identifier;
+}

--- a/packages/uxpin-merge-cli/src/types/acorn-loose.d.ts
+++ b/packages/uxpin-merge-cli/src/types/acorn-loose.d.ts
@@ -15,7 +15,7 @@ export interface ExportDefaultDeclaration extends Node {
 
 export interface ExportNamedDeclaration extends Node {
   type:'ExportNamedDeclaration';
-  declaration: ClassDeclaration|VariableDeclaration|null;
+  declaration: ClassDeclaration|FunctionDeclaration|VariableDeclaration|null;
   specifiers: ExportSpecifier[];
 }
 
@@ -70,6 +70,11 @@ export interface Literal extends Node {
 
 export interface ClassDeclaration extends Node {
   type:'ClassDeclaration';
+  id:Identifier;
+}
+
+export interface FunctionDeclaration extends Node {
+  type:'FunctionDeclaration';
   id:Identifier;
 }
 

--- a/packages/uxpin-merge-cli/src/types/acorn-loose.d.ts
+++ b/packages/uxpin-merge-cli/src/types/acorn-loose.d.ts
@@ -10,7 +10,7 @@ export interface ModuleNode extends Node {
 
 export interface ExportDefaultDeclaration extends Node {
   type:'ExportDefaultDeclaration';
-  declaration: (ObjectExpression|Identifier)
+  declaration: (ObjectExpression|Identifier|CallExpression)
 }
 
 export interface ExportNamedDeclaration extends Node {
@@ -86,4 +86,9 @@ export interface VariableDeclaration extends Node {
 export interface VariableDeclarator extends Node {
   type:'VariableDeclarator';
   id:Identifier;
+}
+
+export interface CallExpression extends Node {
+  type:'CallExpression';
+  arguments:(Identifier|CallExpression)[];
 }

--- a/packages/uxpin-merge-cli/src/types/acorn-loose.d.ts
+++ b/packages/uxpin-merge-cli/src/types/acorn-loose.d.ts
@@ -13,6 +13,12 @@ export interface ExportDefaultDeclaration extends Node {
   declaration: (ObjectExpression|Identifier)
 }
 
+export interface ExportNamedDeclaration extends Node {
+  type:'ExportNamedDeclaration';
+  declaration: VariableDeclaration|null;
+  specifiers: ExportSpecifier[];
+}
+
 export interface ImportDeclaration extends Node {
   type:'ImportDeclaration';
   specifiers: (ImportDefaultSpecifier|ImportSpecifier)[];
@@ -26,6 +32,12 @@ export interface ImportDefaultSpecifier extends Node {
 
 export interface ImportNamespaceSpecifier extends Node {
   type:'ImportNamespaceSpecifier';
+  local:Identifier;
+}
+
+export interface ExportSpecifier extends Node {
+  type:'ExportSpecifier';
+  exported:Identifier;
   local:Identifier;
 }
 
@@ -54,4 +66,14 @@ export interface Property extends Node {
 export interface Literal extends Node {
   type:'Literal';
   value:string;
+}
+
+export interface VariableDeclaration extends Node {
+  type:'VariableDeclaration';
+  declarations:VariableDeclarator[];
+}
+
+export interface VariableDeclarator extends Node {
+  type:'VariableDeclarator';
+  id:Identifier;
 }

--- a/packages/uxpin-merge-cli/test/integration/dump/__snapshots__/mineral-ui-dump.test.ts.snap
+++ b/packages/uxpin-merge-cli/test/integration/dump/__snapshots__/mineral-ui-dump.test.ts.snap
@@ -14471,8 +14471,8 @@ composes [Box](/components/box)",
     "branchName": "master",
     "commitHash": "6a18faefe3d8339b066c92f1a10b27872f15729b",
     "paths": Object {
-      "configPath": "/Users/naohiro/xenon/uxpin/uxpin-merge-tools-new/packages/uxpin-merge-cli/test/resources/repos/mineral-ui/uxpin.config.js",
-      "projectRoot": "/Users/naohiro/xenon/uxpin/uxpin-merge-tools-new/packages/uxpin-merge-cli/test/resources/repos/mineral-ui",
+      "configPath": "/home/circleci/project/packages/uxpin-merge-cli/test/resources/repos/mineral-ui/uxpin.config.js",
+      "projectRoot": "/home/circleci/project/packages/uxpin-merge-cli/test/resources/repos/mineral-ui",
     },
   },
 }

--- a/packages/uxpin-merge-cli/test/integration/dump/__snapshots__/mineral-ui-dump.test.ts.snap
+++ b/packages/uxpin-merge-cli/test/integration/dump/__snapshots__/mineral-ui-dump.test.ts.snap
@@ -6,6 +6,7 @@ Object {
     Object {
       "components": Array [
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -152,6 +153,7 @@ string",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -432,6 +434,7 @@ string",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -739,6 +742,7 @@ primarily for use with uncontrolled components with a \`mode\` prop defined.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -1062,6 +1066,7 @@ specified. See also: \`defaultIndeterminate\`.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -1289,6 +1294,7 @@ use with uncontrolled components.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -1816,6 +1822,7 @@ sibling to the trigger",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -2041,6 +2048,7 @@ text",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -2059,6 +2067,7 @@ text",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -2175,6 +2184,7 @@ text",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -2286,6 +2296,7 @@ text",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -2822,6 +2833,7 @@ See the [React docs](https://reactjs.org/docs/lists-and-keys.html#keys).",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -2840,6 +2852,7 @@ See the [React docs](https://reactjs.org/docs/lists-and-keys.html#keys).",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -2931,6 +2944,7 @@ See the [React docs](https://reactjs.org/docs/lists-and-keys.html#keys).",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -3126,6 +3140,7 @@ our [render props guide](/render-props).",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -3567,6 +3582,7 @@ the trigger",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -3844,6 +3860,7 @@ uncontrolled components",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -4058,6 +4075,7 @@ uncontrolled components.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -4482,6 +4500,7 @@ are truncated ([see example for details](#visible-range))",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -5086,6 +5105,7 @@ to the trigger",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -5412,6 +5432,7 @@ to the trigger",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -6248,6 +6269,7 @@ used by sortable columns",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -6584,6 +6606,7 @@ See also: \`defaultSelectedTabIndex\`",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -6743,6 +6766,7 @@ See also: \`defaultSelectedTabIndex\`",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -7020,6 +7044,7 @@ specified.  Also see \`defaultValue\`.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -7419,6 +7444,7 @@ specified.  Also see \`defaultValue\`.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -7769,6 +7795,7 @@ to the trigger.",
     Object {
       "components": Array [
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -7878,6 +7905,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -7987,6 +8015,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -8032,6 +8061,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -8050,6 +8080,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -8288,6 +8319,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -8343,6 +8375,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -8419,6 +8452,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -8597,6 +8631,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -8694,6 +8729,7 @@ to the trigger.",
     Object {
       "components": Array [
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -8818,6 +8854,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -8930,6 +8967,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -9042,6 +9080,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -9154,6 +9193,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -9266,6 +9306,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -9378,6 +9419,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -9490,6 +9532,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -9602,6 +9645,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -9714,6 +9758,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -9826,6 +9871,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -9938,6 +9984,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -10050,6 +10097,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -10162,6 +10210,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -10274,6 +10323,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -10386,6 +10436,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -10498,6 +10549,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -10610,6 +10662,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -10727,6 +10780,7 @@ to the trigger.",
     Object {
       "components": Array [
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -13194,6 +13248,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -13657,6 +13712,7 @@ to the trigger.",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -13885,6 +13941,7 @@ composes [Box](/components/box)",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -14141,6 +14198,7 @@ composes [Box](/components/box)",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -14213,6 +14271,7 @@ composes [Box](/components/box)",
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -14412,8 +14471,8 @@ composes [Box](/components/box)",
     "branchName": "master",
     "commitHash": "6a18faefe3d8339b066c92f1a10b27872f15729b",
     "paths": Object {
-      "configPath": "/home/circleci/project/packages/uxpin-merge-cli/test/resources/repos/mineral-ui/uxpin.config.js",
-      "projectRoot": "/home/circleci/project/packages/uxpin-merge-cli/test/resources/repos/mineral-ui",
+      "configPath": "/Users/naohiro/xenon/uxpin/uxpin-merge-tools-new/packages/uxpin-merge-cli/test/resources/repos/mineral-ui/uxpin.config.js",
+      "projectRoot": "/Users/naohiro/xenon/uxpin/uxpin-merge-tools-new/packages/uxpin-merge-cli/test/resources/repos/mineral-ui",
     },
   },
 }

--- a/packages/uxpin-merge-cli/test/integration/dump/__snapshots__/namespaced-components-dump.test.ts.snap
+++ b/packages/uxpin-merge-cli/test/integration/dump/__snapshots__/namespaced-components-dump.test.ts.snap
@@ -6,6 +6,7 @@ Object {
     Object {
       "components": Array [
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -110,6 +111,7 @@ Object {
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -151,6 +153,7 @@ Object {
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },

--- a/packages/uxpin-merge-cli/test/integration/dump/__snapshots__/nordnet-ui-kit-dump.test.ts.snap
+++ b/packages/uxpin-merge-cli/test/integration/dump/__snapshots__/nordnet-ui-kit-dump.test.ts.snap
@@ -6,6 +6,7 @@ Object {
     Object {
       "components": Array [
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -26,6 +27,7 @@ Object {
           "properties": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -46,6 +48,7 @@ Object {
           "properties": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -66,6 +69,7 @@ Object {
           "properties": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -86,6 +90,7 @@ Object {
           "properties": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -106,6 +111,7 @@ Object {
           "properties": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -126,6 +132,7 @@ Object {
           "properties": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -529,6 +536,7 @@ Object {
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -660,6 +668,7 @@ Object {
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -897,6 +906,7 @@ Object {
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -917,6 +927,7 @@ Object {
           "properties": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -937,6 +948,7 @@ Object {
           "properties": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -1025,6 +1037,7 @@ Object {
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -1045,6 +1058,7 @@ Object {
           "properties": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -1103,6 +1117,7 @@ Object {
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -1239,6 +1254,7 @@ Object {
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -1259,6 +1275,7 @@ Object {
           "properties": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -1365,6 +1382,7 @@ Object {
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -1537,6 +1555,7 @@ Object {
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -1554,6 +1573,7 @@ Object {
           "properties": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -1636,6 +1656,7 @@ Object {
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -1653,6 +1674,7 @@ Object {
           "properties": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -1759,6 +1781,7 @@ Object {
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -1779,6 +1802,7 @@ Object {
           "properties": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -1921,6 +1945,7 @@ Object {
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -1978,8 +2003,8 @@ Object {
     "branchName": "master",
     "commitHash": "d914edd5f97cadb284f7f47b783106c86fe430d9",
     "paths": Object {
-      "configPath": "/home/circleci/project/packages/uxpin-merge-cli/test/resources/configs/nordnet-ui-kit-uxpin.config.js",
-      "projectRoot": "/home/circleci/project/packages/uxpin-merge-cli/test/resources/repos/nordnet-ui-kit",
+      "configPath": "/Users/naohiro/xenon/uxpin/uxpin-merge-tools-new/packages/uxpin-merge-cli/test/resources/configs/nordnet-ui-kit-uxpin.config.js",
+      "projectRoot": "/Users/naohiro/xenon/uxpin/uxpin-merge-tools-new/packages/uxpin-merge-cli/test/resources/repos/nordnet-ui-kit",
     },
   },
 }

--- a/packages/uxpin-merge-cli/test/integration/dump/__snapshots__/nordnet-ui-kit-dump.test.ts.snap
+++ b/packages/uxpin-merge-cli/test/integration/dump/__snapshots__/nordnet-ui-kit-dump.test.ts.snap
@@ -2003,8 +2003,8 @@ Object {
     "branchName": "master",
     "commitHash": "d914edd5f97cadb284f7f47b783106c86fe430d9",
     "paths": Object {
-      "configPath": "/Users/naohiro/xenon/uxpin/uxpin-merge-tools-new/packages/uxpin-merge-cli/test/resources/configs/nordnet-ui-kit-uxpin.config.js",
-      "projectRoot": "/Users/naohiro/xenon/uxpin/uxpin-merge-tools-new/packages/uxpin-merge-cli/test/resources/repos/nordnet-ui-kit",
+      "configPath": "/home/circleci/project/packages/uxpin-merge-cli/test/resources/configs/nordnet-ui-kit-uxpin.config.js",
+      "projectRoot": "/home/circleci/project/packages/uxpin-merge-cli/test/resources/repos/nordnet-ui-kit",
     },
   },
 }

--- a/packages/uxpin-merge-cli/test/integration/dump/__snapshots__/polaris-dump.test.ts.snap
+++ b/packages/uxpin-merge-cli/test/integration/dump/__snapshots__/polaris-dump.test.ts.snap
@@ -1416,8 +1416,8 @@ Object {
     "branchName": "master",
     "commitHash": "542e947993425fec876e89d1d4bb3c19fca2b5fe",
     "paths": Object {
-      "configPath": "/Users/naohiro/xenon/uxpin/uxpin-merge-tools-new/packages/uxpin-merge-cli/test/resources/repos/polaris/uxpin.config.js",
-      "projectRoot": "/Users/naohiro/xenon/uxpin/uxpin-merge-tools-new/packages/uxpin-merge-cli/test/resources/repos/polaris",
+      "configPath": "/home/circleci/project/packages/uxpin-merge-cli/test/resources/repos/polaris/uxpin.config.js",
+      "projectRoot": "/home/circleci/project/packages/uxpin-merge-cli/test/resources/repos/polaris",
     },
   },
 }

--- a/packages/uxpin-merge-cli/test/integration/dump/__snapshots__/polaris-dump.test.ts.snap
+++ b/packages/uxpin-merge-cli/test/integration/dump/__snapshots__/polaris-dump.test.ts.snap
@@ -6,6 +6,7 @@ Object {
     Object {
       "components": Array [
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -471,6 +472,7 @@ Object {
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -605,6 +607,7 @@ Object {
     Object {
       "components": Array [
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -940,6 +943,7 @@ Object {
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -1007,6 +1011,7 @@ Object {
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -1088,6 +1093,7 @@ Object {
     Object {
       "components": Array [
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -1219,6 +1225,7 @@ Object {
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [
               Object {
@@ -1409,8 +1416,8 @@ Object {
     "branchName": "master",
     "commitHash": "542e947993425fec876e89d1d4bb3c19fca2b5fe",
     "paths": Object {
-      "configPath": "/home/circleci/project/packages/uxpin-merge-cli/test/resources/repos/polaris/uxpin.config.js",
-      "projectRoot": "/home/circleci/project/packages/uxpin-merge-cli/test/resources/repos/polaris",
+      "configPath": "/Users/naohiro/xenon/uxpin/uxpin-merge-tools-new/packages/uxpin-merge-cli/test/resources/repos/polaris/uxpin.config.js",
+      "projectRoot": "/Users/naohiro/xenon/uxpin/uxpin-merge-tools-new/packages/uxpin-merge-cli/test/resources/repos/polaris",
     },
   },
 }

--- a/packages/uxpin-merge-cli/test/integration/presets/__snapshots__/jsx-serialization.test.ts.snap
+++ b/packages/uxpin-merge-cli/test/integration/presets/__snapshots__/jsx-serialization.test.ts.snap
@@ -6,6 +6,7 @@ Object {
     Object {
       "components": Array [
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -76,6 +77,7 @@ Object {
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },
@@ -217,6 +219,7 @@ Object {
           "wrappers": Array [],
         },
         Object {
+          "defaultExported": true,
           "documentation": Object {
             "examples": Array [],
           },

--- a/packages/uxpin-merge-cli/test/resources/designSystems/twoComponentsWithConfig/expectedMetadata.ts
+++ b/packages/uxpin-merge-cli/test/resources/designSystems/twoComponentsWithConfig/expectedMetadata.ts
@@ -2,6 +2,7 @@ import { ComponentDefinition } from '../../../../src/steps/serialization/compone
 import { DesignSystemSnapshot } from '../../../../src/steps/serialization/DesignSystemSnapshot';
 
 export const expectedAvatarMetadata:ComponentDefinition = {
+  defaultExported: true,
   documentation: { examples: [] },
   info: {
     dirPath: 'src/components/Avatar',
@@ -48,6 +49,7 @@ export const expectedAvatarMetadata:ComponentDefinition = {
 };
 
 export const expectedButtonMetadata:ComponentDefinition = {
+  defaultExported: true,
   documentation: { examples: [] },
   info: {
     dirPath: 'src/components/Button',

--- a/packages/uxpin-merge-cli/test/resources/designSystems/watchingChanges/.uxpin-merge/expectedDSWatchingChangesMetadata.ts
+++ b/packages/uxpin-merge-cli/test/resources/designSystems/watchingChanges/.uxpin-merge/expectedDSWatchingChangesMetadata.ts
@@ -2,6 +2,7 @@ import { ComponentDefinition } from '../../../../../src/steps/serialization/comp
 import { DesignSystemSnapshot } from '../../../../../src/steps/serialization/DesignSystemSnapshot';
 
 export const expectedAvatarDefinition:ComponentDefinition = {
+  defaultExported: true,
   documentation: {
     examples: [],
   },
@@ -87,6 +88,7 @@ export const expectedAvatarDefinition:ComponentDefinition = {
 };
 
 export const expectedButtonDefinition:ComponentDefinition = {
+  defaultExported: true,
   documentation: {
     examples: [],
   },


### PR DESCRIPTION
Changes 

1. Added a `defaultExported` attribute to `ComponentMetadata`
2. With `isExportedDefault` function, check if the function is default exported or not by going through AST.
3. Changed `createVirtualModule` to use named export based on `ComponentMetadata`
4. Changed `getLibraryBundleSource` to use named export based on `ComponentMetadata`

