### PR TITLE
Support using custom config for react-docgen parser properly

### DIFF
--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/getDefaultComponentFrom.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/getDefaultComponentFrom.ts
@@ -6,8 +6,8 @@ import { CommentTags } from '../../CommentTags';
 import { hasCommentTag } from './hasCommentTag';
 
 interface ReactDocgenOptionsWithBabelConfig extends ReactDocgenOptions {
-  babelrc:boolean;
-  configFile:boolean;
+  babelrc?:boolean;
+  configFile?:boolean;
 }
 
 // tslint:disable-next-line: max-line-length
@@ -26,15 +26,22 @@ export async function getDefaultComponentFrom(filePath:string):Promise<Component
     importedPropTypesHandler(filePath),
   ];
 
-  // react-docgen has a default set of babel plugins, so trying to use it.
-  // By default, react-docgen try to use users babel config file if it exists.
-  // But there is a case it doesn't work... e.g. storybook/design-system has babel.config.js
-  // which includes preset-typescript. Because of it, react-docgen can't serialize js|jsx file.
+  // Passing `filename` helps babel to load correct babel configuration file.
+  // (NOTE: Without filename option, babel behave as if `babelrc: false` is set)
+  // However, react-docgen has a good set of default babel plugins
+  // and it has been working for most of customers.
+  // I've encountered failure tests from simply setting filename, so,
+  // to make sure we are not breaking existing customers integration by this change, we
+  // 1. try with react-docgen default babel plugins
+  // 2. try with user configured babel config(e.g. .babelrc, babel.config.js)
   const docgenOptions:Array<ReactDocgenOptionsWithBabelConfig | undefined> = [
-    undefined,
     {
       babelrc: false,
       configFile: false,
+      filename: filePath,
+    },
+    {
+      filename: filePath,
     },
   ];
 

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/getDefaultComponentFrom.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/getDefaultComponentFrom.ts
@@ -11,7 +11,7 @@ interface ReactDocgenOptionsWithBabelConfig extends ReactDocgenOptions {
 }
 
 // tslint:disable-next-line: max-line-length
-const parsers:Array<(file:string, handlers:Handler[], options:ReactDocgenOptionsWithBabelConfig | undefined) => ComponentDoc | undefined> = [
+const parsers:Array<(file:string, handlers:Handler[], options:ReactDocgenOptionsWithBabelConfig) => ComponentDoc | undefined> = [
   parseWithAnnotation,
   parseDefault,
 ];
@@ -34,7 +34,7 @@ export async function getDefaultComponentFrom(filePath:string):Promise<Component
   // to make sure we are not breaking existing customers integration by this change, we
   // 1. try with react-docgen default babel plugins
   // 2. try with user configured babel config(e.g. .babelrc, babel.config.js)
-  const docgenOptions:Array<ReactDocgenOptionsWithBabelConfig | undefined> = [
+  const docgenOptions:ReactDocgenOptionsWithBabelConfig[] = [
     {
       babelrc: false,
       configFile: false,
@@ -57,7 +57,6 @@ export async function getDefaultComponentFrom(filePath:string):Promise<Component
         return componentDoc;
       }
     }
-
   }
 
   if (!componentDoc) {
@@ -68,7 +67,7 @@ export async function getDefaultComponentFrom(filePath:string):Promise<Component
 }
 
 function parseWithAnnotation(
-    file:string, handlers:Handler[], options:ReactDocgenOptionsWithBabelConfig | undefined):ComponentDoc | undefined {
+    file:string, handlers:Handler[], options:ReactDocgenOptionsWithBabelConfig):ComponentDoc | undefined {
   const parsed:ComponentDoc[] =
     parse(file, resolver.findAllComponentDefinitions, handlers, options) as ComponentDoc[];
 
@@ -80,6 +79,6 @@ function parseWithAnnotation(
 }
 
 function parseDefault(
-    file:string, handlers:Handler[], options:ReactDocgenOptionsWithBabelConfig | undefined):ComponentDoc | undefined {
+    file:string, handlers:Handler[], options:ReactDocgenOptionsWithBabelConfig):ComponentDoc | undefined {
   return parse(file, undefined, handlers, options) as ComponentDoc;
 }


### PR DESCRIPTION
## How I found out?
When I tried to integrate with [storybook design system](https://github.com/storybookjs/design-system), I've encountered
```
warning Cannot serialize component properties in:
src/components/Button.js
Error: [BABEL] unknown: Preset /* your preset */ requires a filename to be set when babel is called directly,

babel.transform(code, { filename: 'file.ts', presets: [/* your preset */] });
```

## What was the issue?
Storybook DS has `babel.config.js` which includes `preset-typescript`. But it throws above error when react-docgen try to parse with `babel.config.js` without `filename` option. it is recommended to set by [react-docgen](https://github.com/reactjs/react-docgen#-filename) and [babel](https://babeljs.io/docs/en/options#filename) to load babel config correctly. 

## Why it has been working fine for other DS?
[react-docgen has a good set of babel plugins](https://github.com/reactjs/react-docgen/blob/53cef1e0117ae97e07df66b1eb1dabc8c6366e55/src/babelParser.js#L18-L47) when there is no babel config file found. In our case, because we haven't set `filename`, it was using default plugins from react-docgen *UNLESS* there is `babel.config.(js|json)` file.

## Solution
Setting `filename` option

However simply setting `filename` option broke some tests because of the way babel config in the repo.
To prevent breaking existing customers, but also correctly support user configured babel config, we will use react-docgen in 2 ways

1. With react-docgen default babel plugins
2. With user configured babel config(e.g. .babelrc, babel.config.js)