### PR TITLE
Handle utility types like Omit for blacklisting

### DIFF
--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/property/type/getPropertiesFromType.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/property/type/getPropertiesFromType.ts
@@ -25,8 +25,14 @@ export function getPropertiesFromType(type:ts.Type):TypeProps {
 
 function getBasePropertiesFromType(type:ts.Type):ts.Symbol[] {
   return type.getProperties().filter((property, i) => {
+
+    // property.syntheticOrigin is useful when people use utility types
+    // like "Omit" because we need to point back to original type if it's from React or not
     // @ts-ignore
-    if (property.parent?.parent && BLACKLIST_NAMESPACES.includes(property.parent.parent.escapedName)) {
+    // tslint:disable-next-line: max-line-length
+    const parentNameSpace:string | undefined = property.parent?.parent?.escapedName || property.syntheticOrigin?.parent?.parent?.escapedName;
+
+    if (parentNameSpace && BLACKLIST_NAMESPACES.includes(parentNameSpace)) {
       return false;
     }
 

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/property/type/getPropertiesFromType.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/property/type/getPropertiesFromType.ts
@@ -25,9 +25,8 @@ export function getPropertiesFromType(type:ts.Type):TypeProps {
 
 function getBasePropertiesFromType(type:ts.Type):ts.Symbol[] {
   return type.getProperties().filter((property, i) => {
-
     // property.syntheticOrigin is useful when people use utility types
-    // like "Omit" because we need to point back to original type if it's from React or not
+    // like "Omit" because we need to point back to original type to see if it's from React
     // @ts-ignore
     // tslint:disable-next-line: max-line-length
     const parentNameSpace:string | undefined = property.parent?.parent?.escapedName || property.syntheticOrigin?.parent?.parent?.escapedName;


### PR DESCRIPTION
When type is defined with Utility types like `Omit<T, 'attribute'>`, we actually had to step back another level with `syntheticOrigin` to get parent namespace. 
