### PR TITLE
Version Control for Merge Libraries

### DIFF
--- a/packages/uxpin-merge-cli/bin/uxpin-merge
+++ b/packages/uxpin-merge-cli/bin/uxpin-merge
@@ -41,6 +41,7 @@ program
     .option('--config <path>', 'path to a config file. Default: `./uxpin.config.js`')
     .option('--token <token>', 'auth token for the library. Default: `UXPIN_AUTH_TOKEN` env variable')
     .option('--branch <branch>', 'branch to use when uploading. Default: master')
+    .option('--tag <tag>', 'tag this push with a specific name or number. The provided name/number is unique and can be used only once.')
     .action(() => {});
 
 program

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/createTag.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/createTag.ts
@@ -2,7 +2,6 @@ import { isTestEnv } from '../../../program/env/isTestEnv';
 import { requestPromiseWithEnhancedError } from '../../../utils/requestPromiseWithEnhancedError';
 import { getAuthHeaders } from './headers/getAuthHeaders';
 import { getUserAgentHeaders } from './headers/getUserAgentHeaders';
-import { RepositoryPointerType } from './updateRepositoryPointerToBranch';
 
 export async function createTag(
   opts:{
@@ -20,8 +19,7 @@ export async function createTag(
   return requestPromiseWithEnhancedError(`${opts.apiDomain}/code/v/1.0/create-tag`, {
     body: {
       commitHash: opts.commitHash,
-      pointerName: opts.tag,
-      pointerType: RepositoryPointerType.Tag,
+      tagName: opts.tag,
     },
     headers: {
       ...getAuthHeaders(opts.authToken),

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/createTag.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/createTag.ts
@@ -17,35 +17,8 @@ export async function createTag(
     return Promise.resolve();
   }
 
-  if (!opts) { throw new Error('Missing/invalid options'); }
-  if (!opts.apiDomain) { throw new Error('Missing API domain for repository pointer update'); }
-  if (!opts.commitHash) { throw new Error('Missing commit hash for repository pointer update'); }
-  if (!opts.authToken) { throw new Error('Missing auth token for repository pointer update'); }
-
-  // If an optional tag was provided then we need to make a duplicate repository
-  // pointer with type 'tag' that points to the same commit hash
-  if (opts.tag) {
-    try {
-      await createTagRepositoryPointer(opts)
-        .then(() => undefined);
-    } catch (error) {
-      // Could throw error if the tag already exists
-      throw new Error(error.message);
-    }
-  }
-}
-
-async function createTagRepositoryPointer(
-  opts:{
-    apiDomain:string,
-    authToken:string,
-    commitHash:string,
-    tag:string,
-  }):Promise<void> {
-
   return requestPromiseWithEnhancedError(`${opts.apiDomain}/code/v/1.0/create-tag`, {
     body: {
-      authToken: opts.authToken,
       commitHash: opts.commitHash,
       pointerName: opts.tag,
       pointerType: RepositoryPointerType.Tag,
@@ -56,6 +29,5 @@ async function createTagRepositoryPointer(
     },
     json: true,
     method: 'POST',
-  })
-    .then(() => undefined);
+  }).then(() => undefined);
 }

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/createTag.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/createTag.ts
@@ -2,18 +2,12 @@ import { isTestEnv } from '../../../program/env/isTestEnv';
 import { requestPromiseWithEnhancedError } from '../../../utils/requestPromiseWithEnhancedError';
 import { getAuthHeaders } from './headers/getAuthHeaders';
 import { getUserAgentHeaders } from './headers/getUserAgentHeaders';
-import { encodeBranchName } from './params/encodeBranchName';
+import { RepositoryPointerType } from './updateRepositoryPointerToBranch';
 
-export const enum RepositoryPointerType {
-  Branch = 'branch',
-  Tag = 'tag',
-}
-
-export async function updateRepositoryPointerToBranchOrTag(
+export async function createTag(
   opts:{
     apiDomain:string,
     authToken:string,
-    branch:string,
     commitHash:string,
     tag:string,
   }):Promise<void> {
@@ -27,56 +21,24 @@ export async function updateRepositoryPointerToBranchOrTag(
   if (!opts.apiDomain) { throw new Error('Missing API domain for repository pointer update'); }
   if (!opts.commitHash) { throw new Error('Missing commit hash for repository pointer update'); }
   if (!opts.authToken) { throw new Error('Missing auth token for repository pointer update'); }
-  if (!opts.branch) { throw new Error('Missing branch name for repository pointer update'); }
 
   // If an optional tag was provided then we need to make a duplicate repository
   // pointer with type 'tag' that points to the same commit hash
   if (opts.tag) {
     try {
-      await createTag(opts)
+      await createTagRepositoryPointer(opts)
         .then(() => undefined);
     } catch (error) {
       // Could throw error if the tag already exists
       throw new Error(error.message);
     }
   }
-
-  return updateRepositoryPointerToBranch(opts)
-    .then(() => undefined);
 }
 
-async function updateRepositoryPointerToBranch(
+async function createTagRepositoryPointer(
   opts:{
     apiDomain:string,
     authToken:string,
-    branch:string,
-    commitHash:string,
-    tag:string,
-  }):Promise<void> {
-
-  const branchName:string = encodeBranchName(opts.branch);
-
-  return requestPromiseWithEnhancedError(`${opts.apiDomain}/code/v/1.0/update-repository-pointer`, {
-    body: {
-      commitHash: opts.commitHash,
-      pointerName: branchName,
-      pointerType: RepositoryPointerType.Branch,
-    },
-    headers: {
-      ...getAuthHeaders(opts.authToken),
-      ...getUserAgentHeaders(),
-    },
-    json: true,
-    method: 'POST',
-  })
-    .then(() => undefined);
-}
-
-async function createTag(
-  opts:{
-    apiDomain:string,
-    authToken:string,
-    branch:string,
     commitHash:string,
     tag:string,
   }):Promise<void> {

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/updateRepositoryPointerToBranch.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/updateRepositoryPointerToBranch.ts
@@ -1,0 +1,47 @@
+import { isTestEnv } from '../../../program/env/isTestEnv';
+import { requestPromiseWithEnhancedError } from '../../../utils/requestPromiseWithEnhancedError';
+import { getAuthHeaders } from './headers/getAuthHeaders';
+import { getUserAgentHeaders } from './headers/getUserAgentHeaders';
+import { encodeBranchName } from './params/encodeBranchName';
+
+export const enum RepositoryPointerType {
+  Branch = 'branch',
+  Tag = 'tag',
+}
+
+export async function updateRepositoryPointerToBranch(
+  opts:{
+    apiDomain:string,
+    authToken:string,
+    branch:string,
+    commitHash:string,
+  }):Promise<void> {
+
+  // Skip updating repository pointers in test environment
+  if (isTestEnv()) {
+    return Promise.resolve();
+  }
+
+  if (!opts) { throw new Error('Missing/invalid options'); }
+  if (!opts.apiDomain) { throw new Error('Missing API domain for repository pointer update'); }
+  if (!opts.branch) { throw new Error('Missing branch name for repository pointer update'); }
+  if (!opts.commitHash) { throw new Error('Missing commit hash for repository pointer update'); }
+  if (!opts.authToken) { throw new Error('Missing auth token for repository pointer update'); }
+
+  const branchName:string = encodeBranchName(opts.branch);
+
+  return requestPromiseWithEnhancedError(`${opts.apiDomain}/code/v/1.0/update-repository-pointer`, {
+    body: {
+      commitHash: opts.commitHash,
+      pointerName: branchName,
+      pointerType: RepositoryPointerType.Branch,
+    },
+    headers: {
+      ...getAuthHeaders(opts.authToken),
+      ...getUserAgentHeaders(),
+    },
+    json: true,
+    method: 'POST',
+  })
+    .then(() => undefined);
+}

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/updateRepositoryPointerToBranch.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/updateRepositoryPointerToBranch.ts
@@ -22,12 +22,6 @@ export async function updateRepositoryPointerToBranch(
     return Promise.resolve();
   }
 
-  if (!opts) { throw new Error('Missing/invalid options'); }
-  if (!opts.apiDomain) { throw new Error('Missing API domain for repository pointer update'); }
-  if (!opts.branch) { throw new Error('Missing branch name for repository pointer update'); }
-  if (!opts.commitHash) { throw new Error('Missing commit hash for repository pointer update'); }
-  if (!opts.authToken) { throw new Error('Missing auth token for repository pointer update'); }
-
   const branchName:string = encodeBranchName(opts.branch);
 
   return requestPromiseWithEnhancedError(`${opts.apiDomain}/code/v/1.0/update-repository-pointer`, {

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/updateRepositoryPointerToBranchOrTag.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/updateRepositoryPointerToBranchOrTag.ts
@@ -9,12 +9,13 @@ export const enum RepositoryPointerType {
   Tag = 'tag',
 }
 
-export async function updateRepositoryPointerToBranch(
+export async function updateRepositoryPointerToBranchOrTag(
   opts:{
     apiDomain:string,
     authToken:string,
     branch:string,
     commitHash:string,
+    tag:string,
   }):Promise<void> {
 
   // Skip updating repository pointers in test environment
@@ -24,9 +25,30 @@ export async function updateRepositoryPointerToBranch(
 
   if (!opts) { throw new Error('Missing/invalid options'); }
   if (!opts.apiDomain) { throw new Error('Missing API domain for repository pointer update'); }
-  if (!opts.branch) { throw new Error('Missing branch name for repository pointer update'); }
   if (!opts.commitHash) { throw new Error('Missing commit hash for repository pointer update'); }
   if (!opts.authToken) { throw new Error('Missing auth token for repository pointer update'); }
+
+  // If an optional tag was provided then we need to make a duplicate repository
+  // pointer with type 'tag' that points to the same commit hash
+  if (opts.tag) {
+    updateRepositoryPointerToTag(opts)
+      .then(() => undefined);
+  }
+
+  return updateRepositoryPointerToBranch(opts)
+    .then(() => undefined);
+}
+
+async function updateRepositoryPointerToBranch(
+  opts:{
+    apiDomain:string,
+    authToken:string,
+    branch:string,
+    commitHash:string,
+    tag:string,
+  }):Promise<void> {
+
+  if (!opts.branch) { throw new Error('Missing branch name for repository pointer update'); }
 
   const branchName:string = encodeBranchName(opts.branch);
 
@@ -35,6 +57,33 @@ export async function updateRepositoryPointerToBranch(
       commitHash: opts.commitHash,
       pointerName: branchName,
       pointerType: RepositoryPointerType.Branch,
+    },
+    headers: {
+      ...getAuthHeaders(opts.authToken),
+      ...getUserAgentHeaders(),
+    },
+    json: true,
+    method: 'POST',
+  })
+    .then(() => undefined);
+}
+
+async function updateRepositoryPointerToTag(
+  opts:{
+    apiDomain:string,
+    authToken:string,
+    branch:string,
+    commitHash:string,
+    tag:string,
+  }):Promise<void> {
+
+  if (!opts.tag) { throw new Error('Missing tag for repository pointer update'); }
+
+  return requestPromiseWithEnhancedError(`${opts.apiDomain}/code/v/1.0/update-repository-pointer`, {
+    body: {
+      commitHash: opts.commitHash,
+      pointerName: opts.tag,
+      pointerType: RepositoryPointerType.Tag,
     },
     headers: {
       ...getAuthHeaders(opts.authToken),

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/updateRepositoryPointerToBranchOrTag.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/updateRepositoryPointerToBranchOrTag.ts
@@ -32,16 +32,12 @@ export async function updateRepositoryPointerToBranchOrTag(
   // If an optional tag was provided then we need to make a duplicate repository
   // pointer with type 'tag' that points to the same commit hash
   if (opts.tag) {
-    // Temp condition: 1.0 is a tag that hypothetically exists
-    if (opts.tag === '1.0') {
-      throw new Error(`This tag [${opts.tag}] already exists. Please provide another identifer and try again.`);
-    }
-
     try {
       await createTag(opts)
         .then(() => undefined);
     } catch (error) {
-      throw new Error('Unable to create Tag');
+      // Could throw error if the tag already exists
+      throw new Error(error.message);
     }
   }
 

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/updateRepositoryPointerToBranchOrTag.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/updateRepositoryPointerToBranchOrTag.ts
@@ -37,8 +37,12 @@ export async function updateRepositoryPointerToBranchOrTag(
       throw new Error(`This tag [${opts.tag}] already exists. Please provide another identifer and try again.`);
     }
 
-    updateRepositoryPointerToTag(opts)
-      .then(() => undefined);
+    try {
+      await createTag(opts)
+        .then(() => undefined);
+    } catch (error) {
+      throw new Error('Unable to create Tag');
+    }
   }
 
   return updateRepositoryPointerToBranch(opts)
@@ -72,7 +76,7 @@ async function updateRepositoryPointerToBranch(
     .then(() => undefined);
 }
 
-async function updateRepositoryPointerToTag(
+async function createTag(
   opts:{
     apiDomain:string,
     authToken:string,
@@ -81,8 +85,9 @@ async function updateRepositoryPointerToTag(
     tag:string,
   }):Promise<void> {
 
-  return requestPromiseWithEnhancedError(`${opts.apiDomain}/code/v/1.0/update-repository-pointer`, {
+  return requestPromiseWithEnhancedError(`${opts.apiDomain}/code/v/1.0/create-tag`, {
     body: {
+      authToken: opts.authToken,
       commitHash: opts.commitHash,
       pointerName: opts.tag,
       pointerType: RepositoryPointerType.Tag,

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/updateRepositoryPointerToBranchOrTag.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/updateRepositoryPointerToBranchOrTag.ts
@@ -27,10 +27,16 @@ export async function updateRepositoryPointerToBranchOrTag(
   if (!opts.apiDomain) { throw new Error('Missing API domain for repository pointer update'); }
   if (!opts.commitHash) { throw new Error('Missing commit hash for repository pointer update'); }
   if (!opts.authToken) { throw new Error('Missing auth token for repository pointer update'); }
+  if (!opts.branch) { throw new Error('Missing branch name for repository pointer update'); }
 
   // If an optional tag was provided then we need to make a duplicate repository
   // pointer with type 'tag' that points to the same commit hash
   if (opts.tag) {
+    // Temp condition: 1.0 is a tag that hypothetically exists
+    if (opts.tag === '1.0') {
+      throw new Error(`This tag [${opts.tag}] already exists. Please provide another identifer and try again.`);
+    }
+
     updateRepositoryPointerToTag(opts)
       .then(() => undefined);
   }
@@ -47,8 +53,6 @@ async function updateRepositoryPointerToBranch(
     commitHash:string,
     tag:string,
   }):Promise<void> {
-
-  if (!opts.branch) { throw new Error('Missing branch name for repository pointer update'); }
 
   const branchName:string = encodeBranchName(opts.branch);
 
@@ -76,8 +80,6 @@ async function updateRepositoryPointerToTag(
     commitHash:string,
     tag:string,
   }):Promise<void> {
-
-  if (!opts.tag) { throw new Error('Missing tag for repository pointer update'); }
 
   return requestPromiseWithEnhancedError(`${opts.apiDomain}/code/v/1.0/update-repository-pointer`, {
     body: {

--- a/packages/uxpin-merge-cli/src/program/args/ProgramArgs.ts
+++ b/packages/uxpin-merge-cli/src/program/args/ProgramArgs.ts
@@ -60,6 +60,7 @@ export interface PushProgramArgs {
   // Branch name to use as an override (normally for detached head state)
   // https://github.com/UXPin/uxpin-merge-tools/issues/206
   branch?:string;
+  tag?:string;
 }
 
 export interface GeneratePresetsProgramArgs {

--- a/packages/uxpin-merge-cli/src/program/command/push/getBuildOptions.ts
+++ b/packages/uxpin-merge-cli/src/program/command/push/getBuildOptions.ts
@@ -14,11 +14,12 @@ function getDefaultApiDomain(domain:string):string {
 }
 
 export function getBuildOptions(args:BuildProgramArgs):BuildOptions {
-  const { token, uxpinDomain, webpackConfig, wrapper, branch } = args;
+  const { token, uxpinDomain, webpackConfig, wrapper, branch, tag } = args;
 
   return {
     branch,
     projectRoot: getProjectRoot(args),
+    tag,
     token,
     uxpinApiDomain: getDefaultApiDomain(uxpinDomain!),
     uxpinDirPath: getTempDirPath(args),
@@ -29,4 +30,4 @@ export function getBuildOptions(args:BuildProgramArgs):BuildOptions {
 }
 
 export type BuildProgramArgs = Pick<PushProgramArgs, 'cwd' | 'token'
-  | 'uxpinDomain' | 'webpackConfig' | 'wrapper' | 'branch'>;
+  | 'uxpinDomain' | 'webpackConfig' | 'wrapper' | 'branch' | 'tag'>;

--- a/packages/uxpin-merge-cli/src/program/command/push/steps/uploadLibrary.ts
+++ b/packages/uxpin-merge-cli/src/program/command/push/steps/uploadLibrary.ts
@@ -48,23 +48,40 @@ export function uploadLibrary(buildOptions:BuildOptions):StepExecutor {
     }
 
     // If the backend already has the commit we're trying to push,
-    // Update the repository pointer to the current branch and exit early
+    // Update the repository pointer to the current branch/tag and exit early
     if (isSameVersion(designSystem.result)) {
-      printLine('✅ Library is up-to-date!', { color: PrintColor.GREEN });
+      try {
+        printLine('✅ Library is up-to-date!', { color: PrintColor.GREEN });
 
-      // Update the repository pointer to point to the new branch
-      await updateRepositoryPointerToBranchOrTag({
-        apiDomain,
-        authToken,
-        branch,
-        commitHash,
-        tag,
-      });
+        // Update the repository pointer to point to the new branch and/or tag
+        await updateRepositoryPointerToBranchOrTag({
+          apiDomain,
+          authToken,
+          branch,
+          commitHash,
+          tag,
+        });
 
-      printLine(
-        `🛈  Projects using this Design System have been updated to branch [${branch}]`,
-        { color: PrintColor.CYAN },
-      );
+        printLine(
+          `🛈  Projects using this Design System have been updated to branch [${branch}]`,
+          { color: PrintColor.CYAN },
+        );
+
+        if (tag) {
+          printLine(
+            `🏷️  Library tagged at this point in time with tag [${tag}] at commit hash [${commitHash}]`,
+            { color: PrintColor.YELLOW },
+          );
+        }
+
+        return designSystem;
+      } catch (error) {
+        printLine(
+          `🛑 There was an error while updating the branch or tag design system pointers.`,
+          { color: PrintColor.RED },
+        );
+        throw new Error(error.message);
+      }
 
       return designSystem;
     }
@@ -103,9 +120,17 @@ export function uploadLibrary(buildOptions:BuildOptions):StepExecutor {
         tag,
       });
       printLine(`✅ Projects set to use DS branch [${vcsDetails.branchName}]!`, { color: PrintColor.GREEN });
+
+      if (tag) {
+        printLine(
+          `🏷️  Library tagged at this point in time with tag [${tag}] at commit hash [${commitHash}]`,
+          { color: PrintColor.YELLOW },
+        );
+      }
+
     } catch (error) {
       printLine(
-        `🛑 There was an error while updating design system pointers [${vcsDetails.branchName}] .`,
+        `🛑 There was an error while updating the branch or tag design system pointers.`,
         { color: PrintColor.RED },
       );
       throw new Error(error.message);

--- a/packages/uxpin-merge-cli/src/program/command/push/steps/uploadLibrary.ts
+++ b/packages/uxpin-merge-cli/src/program/command/push/steps/uploadLibrary.ts
@@ -1,10 +1,11 @@
 import { resolve } from 'path';
 import { DEFAULT_BRANCH_NAME } from '../../../../common/constants';
+import { createTag } from '../../../../common/services/UXPin/createTag';
 import { getApiDomain } from '../../../../common/services/UXPin/getApiDomain';
 import { getLatestCommitHash } from '../../../../common/services/UXPin/getLatestCommitHash';
 import { postPushMetadata } from '../../../../common/services/UXPin/postPushMetadata';
 import { postUploadBundle } from '../../../../common/services/UXPin/postUploadBundle';
-import { updateRepositoryPointerToBranchOrTag } from '../../../../common/services/UXPin/updateRepositoryPointerToBranchOrTag';
+import { updateRepositoryPointerToBranch } from '../../../../common/services/UXPin/updateRepositoryPointerToBranch';
 import { DSMetadata } from '../../../../program/DSMeta';
 import { BuildOptions } from '../../../../steps/building/BuildOptions';
 import { LIBRARY_OUTPUT_FILENAME } from '../../../../steps/building/config/getConfig';
@@ -48,18 +49,17 @@ export function uploadLibrary(buildOptions:BuildOptions):StepExecutor {
     }
 
     // If the backend already has the commit we're trying to push,
-    // Update the repository pointer to the current branch/tag and exit early
+    // Update the repository pointer to the current branch and exit early
     if (isSameVersion(designSystem.result)) {
       try {
         printLine('✅ Library is up-to-date!', { color: PrintColor.GREEN });
 
-        // Update the repository pointer to point to the new branch and/or tag
-        await updateRepositoryPointerToBranchOrTag({
+        // Update the repository pointer to point to the new branch
+        await updateRepositoryPointerToBranch({
           apiDomain,
           authToken,
           branch,
           commitHash,
-          tag,
         });
 
         printLine(
@@ -68,6 +68,13 @@ export function uploadLibrary(buildOptions:BuildOptions):StepExecutor {
         );
 
         if (tag) {
+          await createTag({
+            apiDomain,
+            authToken,
+            commitHash,
+            tag,
+          });
+
           printLine(
             `🏷️  Library tagged at this point in time with tag [${tag}] at commit hash [${commitHash}]`,
             { color: PrintColor.YELLOW },
@@ -112,16 +119,22 @@ export function uploadLibrary(buildOptions:BuildOptions):StepExecutor {
     }
 
     try {
-      await updateRepositoryPointerToBranchOrTag({
+      await updateRepositoryPointerToBranch({
         apiDomain,
         authToken,
         branch,
         commitHash,
-        tag,
       });
       printLine(`✅ Projects set to use DS branch [${vcsDetails.branchName}]!`, { color: PrintColor.GREEN });
 
       if (tag) {
+        await createTag({
+          apiDomain,
+          authToken,
+          commitHash,
+          tag,
+        });
+
         printLine(
           `🏷️  Library tagged at this point in time with tag [${tag}] at commit hash [${commitHash}]`,
           { color: PrintColor.YELLOW },

--- a/packages/uxpin-merge-cli/src/program/command/push/steps/uploadLibrary.ts
+++ b/packages/uxpin-merge-cli/src/program/command/push/steps/uploadLibrary.ts
@@ -52,47 +52,21 @@ export function uploadLibrary(buildOptions:BuildOptions):StepExecutor {
     // Update the repository pointer to the current branch and exit early
     if (isSameVersion(designSystem.result)) {
       printLine('✅ Library is up-to-date!', { color: PrintColor.GREEN });
-      try {
         // Update the repository pointer to point to the new branch
-        await updateRepositoryPointerToBranch({
-          apiDomain,
-          authToken,
-          branch,
-          commitHash,
-        });
-
-        printLine(
-          `🛈  Projects using this Design System have been updated to branch [${branch}]`,
-          { color: PrintColor.CYAN },
-        );
-      } catch (error) {
-        printLine(
-          `🛑 There was an error while updating design system pointers [${vcsDetails.branchName}]`,
-          { color: PrintColor.RED },
-        );
-        throw new Error(error.message);
-      }
+      await updateRepositoryPointerWithPrintMessage({
+        apiDomain,
+        authToken,
+        branch,
+        commitHash,
+      });
 
       if (tag) {
-        try {
-          await createTag({
-            apiDomain,
-            authToken,
-            commitHash,
-            tag,
-          });
-
-          printLine(
-            `🏷️  Library tagged at this point in time with tag [${tag}] at commit hash [${commitHash}]`,
-            { color: PrintColor.YELLOW },
-          );
-        } catch (error) {
-          printLine(
-            `🛑 There was an error while creating a tag [${tag}] at commit hash [${commitHash}]`,
-            { color: PrintColor.RED },
-          );
-          throw new Error(error.message);
-        }
+        await createTagWithPrintMessage({
+          apiDomain,
+          authToken,
+          commitHash,
+          tag,
+        });
       }
 
       return designSystem;
@@ -123,44 +97,66 @@ export function uploadLibrary(buildOptions:BuildOptions):StepExecutor {
       throw new Error(error.message);
     }
 
-    try {
-      await updateRepositoryPointerToBranch({
-        apiDomain,
-        authToken,
-        branch,
-        commitHash,
-      });
-      printLine(`✅ Projects set to use DS branch [${vcsDetails.branchName}]!`, { color: PrintColor.GREEN });
-    } catch (error) {
-      printLine(
-        `🛑 There was an error while updating design system pointers [${vcsDetails.branchName}]`,
-        { color: PrintColor.RED },
-      );
-      throw new Error(error.message);
-    }
+    await updateRepositoryPointerWithPrintMessage({
+      apiDomain,
+      authToken,
+      branch,
+      commitHash,
+    });
 
     if (tag) {
-      try {
-        await createTag({
-          apiDomain,
-          authToken,
-          commitHash,
-          tag,
-        });
-
-        printLine(
-          `🏷️  Library tagged at this point in time with tag [${tag}] at commit hash [${commitHash}]`,
-          { color: PrintColor.YELLOW },
-        );
-      } catch (error) {
-        printLine(
-          `🛑 There was an error while creating a tag [${tag}] at commit hash [${commitHash}]`,
-          { color: PrintColor.RED },
-        );
-        throw new Error(error.message);
-      }
+      await createTagWithPrintMessage({
+        apiDomain,
+        authToken,
+        commitHash,
+        tag,
+      });
     }
 
     return designSystem;
   };
+}
+
+async function createTagWithPrintMessage(opts:{
+  apiDomain:string,
+  authToken:string,
+  commitHash:string,
+  tag:string,
+}):Promise<void> {
+  try {
+    await createTag(opts);
+    printLine(
+      `🏷️  Library tagged at this point in time with tag [${opts.tag}] at commit hash [${opts.commitHash}]`,
+      { color: PrintColor.YELLOW },
+    );
+  } catch (error) {
+    printLine(
+      `🛑 There was an error while creating a tag [${opts.tag}] at commit hash [${opts.commitHash}]`,
+      { color: PrintColor.RED },
+    );
+    throw new Error(error.message);
+  }
+}
+
+async function updateRepositoryPointerWithPrintMessage(opts:{
+  apiDomain:string,
+  authToken:string,
+  branch:string,
+  commitHash:string,
+}):Promise<void> {
+  try {
+    // Update the repository pointer to point to the new branch
+    await updateRepositoryPointerToBranch(opts);
+
+    printLine(
+      `🛈  Projects using this Design System have been updated to branch [${opts.branch}]`,
+      { color: PrintColor.CYAN },
+    );
+  } catch (error) {
+    printLine(
+      `🛑 There was an error while updating design system pointers [${opts.branch}]`,
+      { color: PrintColor.RED },
+    );
+    throw new Error(error.message);
+  }
 }

--- a/packages/uxpin-merge-cli/src/program/command/push/steps/uploadLibrary.ts
+++ b/packages/uxpin-merge-cli/src/program/command/push/steps/uploadLibrary.ts
@@ -4,7 +4,7 @@ import { getApiDomain } from '../../../../common/services/UXPin/getApiDomain';
 import { getLatestCommitHash } from '../../../../common/services/UXPin/getLatestCommitHash';
 import { postPushMetadata } from '../../../../common/services/UXPin/postPushMetadata';
 import { postUploadBundle } from '../../../../common/services/UXPin/postUploadBundle';
-import { updateRepositoryPointerToBranch } from '../../../../common/services/UXPin/updateRepositoryPointerToBranch';
+import { updateRepositoryPointerToBranchOrTag } from '../../../../common/services/UXPin/updateRepositoryPointerToBranchOrTag';
 import { DSMetadata } from '../../../../program/DSMeta';
 import { BuildOptions } from '../../../../steps/building/BuildOptions';
 import { LIBRARY_OUTPUT_FILENAME } from '../../../../steps/building/config/getConfig';
@@ -23,6 +23,7 @@ export function uploadLibrary(buildOptions:BuildOptions):StepExecutor {
     const commitHash:string = vcsDetails.commitHash;
     const path:string = resolve(buildOptions.uxpinDirPath, LIBRARY_OUTPUT_FILENAME);
     const branch:string = vcsDetails && vcsDetails.branchName ? vcsDetails.branchName : DEFAULT_BRANCH_NAME;
+    const tag:string = buildOptions.tag!;
 
     // Get the latest commit hash known by the backend
     // NOTE: if the branch has changed locally, but latest commit has not (so a fresh branch)
@@ -52,11 +53,12 @@ export function uploadLibrary(buildOptions:BuildOptions):StepExecutor {
       printLine('✅ Library is up-to-date!', { color: PrintColor.GREEN });
 
       // Update the repository pointer to point to the new branch
-      await updateRepositoryPointerToBranch({
+      await updateRepositoryPointerToBranchOrTag({
         apiDomain,
         authToken,
         branch,
         commitHash,
+        tag,
       });
 
       printLine(
@@ -93,11 +95,12 @@ export function uploadLibrary(buildOptions:BuildOptions):StepExecutor {
     }
 
     try {
-      await updateRepositoryPointerToBranch({
+      await updateRepositoryPointerToBranchOrTag({
         apiDomain,
         authToken,
         branch,
         commitHash,
+        tag,
       });
       printLine(`✅ Projects set to use DS branch [${vcsDetails.branchName}]!`, { color: PrintColor.GREEN });
     } catch (error) {

--- a/packages/uxpin-merge-cli/src/steps/building/BuildOptions.ts
+++ b/packages/uxpin-merge-cli/src/steps/building/BuildOptions.ts
@@ -8,4 +8,5 @@ export interface BuildOptions {
   webpackConfigPath?:string;
   wrapperPath?:string;
   branch?:string;
+  tag?:string;
 }


### PR DESCRIPTION
CLI component of [this issue](https://github.com/UXPin/uxpin-issues/issues/381)

- [x] Add a new `tag` option to the `push` command
- [x] Add validation to ensure that a tag identifier can only be used once
- [x] CLI : Specifying a tag will create a duplicate repository pointer pointing to the same commit hash as the branch being pushed   
- [x] API : Specifying a tag will create a duplicate repository pointer pointing to the same commit hash as the branch being pushed. See [this PR](https://github.com/UXPin/uxpin-api/pull/951)

## Example of successfully setting a tag:

```
$ uxpin-merge push --token YOUR_TOKEN --branch feature-branch-3 --tag 3.1

✅ Library is up-to-date!
🛈  Projects using this Design System have been updated to branch [feature-branch-3]
🏷️  Library tagged at this point in time with tag [3.1] at commit hash [d6fca0bb9a03943aa66b002d6d881765e998c3eb]
```
## Example of validation preventing the same tag from being used twice:

```
$ uxpin-merge push --token YOUR_TOKEN --branch feature-branch-3 --tag 3.0

✅ Library is up-to-date!
🛑 There was an error while updating the branch or tag design system pointers.
ERROR: This tag [3.0] already exists. Please provide another identifer and try again.
```