### PR TITLE
Allow push from branch without making any new commits

### DIFF
--- a/packages/uxpin-merge-cli/src/steps/serialization/vcs/repositories/git/util/getBranchesAtCommit.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/vcs/repositories/git/util/getBranchesAtCommit.ts
@@ -10,11 +10,11 @@ export async function getBranchesAtCommit(cwd:string, fullCommitHash:string):Pro
   const rawReflogOutput:string = await execAsync('git reflog --all', { cwd });
   rawReflogOutput
     .split('\n')
-  // Filter out HEAD, the commit in question, and keep only top-level current commits
-    .filter((l) => !l.includes('HEAD') && !l.includes(fullCommitHash) && l.includes('@{0}'))
-  // Filter out lines that do not contain
+    // Filter out HEAD, the commit in question, and keep only top-level current commits
+    .filter((l) => !l.includes('HEAD@') && !l.includes(fullCommitHash) && l.includes('@{0}'))
+    // Filter out lines that do not contain
     .filter((l) => l.includes(currentShortHash))
-  // Convert the line to a structured object
+    // Convert the line to a structured object
     .forEach((l) => {
       // tslint:disable-next-line:no-unused-variable
       const [shortCommitHash, ref, ...rest] = l.split(/\s+/);


### PR DESCRIPTION
Currently, if you try to push a branch right after you create one, it raises following message.
`🛑 The current commit is not on branch...`

Steps to reproduce
1. git checkout -b feature_a
2. npx uxpin-merge push --token TOKEN --branch feature_a

This is because we filter some reflog messages. And one of the filter is, skipping message includes `HEAD` when we really want to skip `HEAD@`.
e.g. Below is the message when you run `git checkout -b test`
`refs/heads/test@{0}: branch: Created from HEAD`

Following message is something we would like to skip
`HEAD@{0}: checkout: moving from main to test`