### PR TITLE
Allow pushing a branch created from specific sha

### DIFF
--- a/packages/uxpin-merge-cli/src/steps/serialization/vcs/repositories/git/util/getBranchesAtCommit.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/vcs/repositories/git/util/getBranchesAtCommit.ts
@@ -11,7 +11,7 @@ export async function getBranchesAtCommit(cwd:string, fullCommitHash:string):Pro
   rawReflogOutput
     .split('\n')
     // Filter out HEAD, the commit in question, and keep only top-level current commits
-    .filter((l) => !l.includes('HEAD@') && !l.includes(fullCommitHash) && l.includes('@{0}'))
+    .filter((l) => !l.includes('HEAD@') && l.includes('@{0}'))
     // Filter out lines that do not contain
     .filter((l) => l.includes(currentShortHash))
     // Convert the line to a structured object


### PR DESCRIPTION
CircleCI checkout branch with following command
`git checkout -B branch_name commit_sha`

In this case, `git reflog --all` command returns something like following message
`a11d0c7e (HEAD -> test_2) refs/heads/test_2@{0}: branch: Created from a11d0c7e9877968bd8d4f116e3951ca4d064ec4b`

Because of `!l.includes(fullCommitHash)` which I removed in this PR, our user is facing an issue with pushing with following message
`🛑 The current commit is not on branch [master], please specify --branch to use a custom branch`

Filter reflog message with a full commit hash seems unnecessary to filter `HEAD` related messages, so I believe this is safe to remove. 