### PR TITLE
Delete tag or branch for version control

### DIFF
--- a/packages/uxpin-merge-cli/bin/uxpin-merge
+++ b/packages/uxpin-merge-cli/bin/uxpin-merge
@@ -49,7 +49,8 @@ program
     .description('Delete the selected tag or branch in the Merge library')
     .option('--token <token>', 'auth token for the library to delete from.')
     .option('--branch <branch>', 'branch to delete in the Merge library')
-    .option('--tag <tag>', 'tag to delete in the Merge library')    
+    .option('--tag <tag>', 'tag to delete in the Merge library')
+    .action(() => {});    
 
 program
     .command(Command.DUMP)

--- a/packages/uxpin-merge-cli/bin/uxpin-merge
+++ b/packages/uxpin-merge-cli/bin/uxpin-merge
@@ -45,6 +45,13 @@ program
     .action(() => {});
 
 program
+    .command(Command.DELETE_VERSION)
+    .description('Delete the selected tag or branch in the Merge library')
+    .option('--token <token>', 'auth token for the library to delete from.')
+    .option('--branch <branch>', 'branch to delete in the Merge library')
+    .option('--tag <tag>', 'tag to delete in the Merge library')    
+
+program
     .command(Command.DUMP)
     .description('Shows all information (in JSON) about the design system repository and NOT send to UXPin')
     .option('--cwd <path>', 'working directory: path to root of the DS repository')

--- a/packages/uxpin-merge-cli/src/common/RepositoryPointerType.ts
+++ b/packages/uxpin-merge-cli/src/common/RepositoryPointerType.ts
@@ -1,0 +1,4 @@
+export const enum RepositoryPointerType {
+    Branch = 'branch',
+    Tag = 'tag',
+}

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/DeleteRepositoryPointerToBranch.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/DeleteRepositoryPointerToBranch.ts
@@ -1,13 +1,9 @@
+import { RepositoryPointerType } from '../../../../src/common/RepositoryPointerType';
 import { isTestEnv } from '../../../program/env/isTestEnv';
 import { requestPromiseWithEnhancedError } from '../../../utils/requestPromiseWithEnhancedError';
 import { getAuthHeaders } from './headers/getAuthHeaders';
 import { getUserAgentHeaders } from './headers/getUserAgentHeaders';
 import { encodeBranchName } from './params/encodeBranchName';
-
-export const enum RepositoryPointerType {
-    Branch = 'branch',
-    Tag = 'tag',
-}
 
 export async function deleteRepositoryPointerToBranch(
     opts:{
@@ -23,7 +19,7 @@ export async function deleteRepositoryPointerToBranch(
 
   const branchName:string = encodeBranchName(opts.branch);
 
-  return requestPromiseWithEnhancedError(`${opts.apiDomain}/code/v/1.0/delete-repository-pointer`, {
+  await requestPromiseWithEnhancedError(`${opts.apiDomain}/code/v/1.0/delete-repository-pointer`, {
     body: {
       pointerName: branchName,
       pointerType: RepositoryPointerType.Branch,
@@ -34,5 +30,5 @@ export async function deleteRepositoryPointerToBranch(
     },
     json: true,
     method: 'DELETE',
-  }).then(() => undefined);
+  });
 }

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/DeleteRepositoryPointerToBranch.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/DeleteRepositoryPointerToBranch.ts
@@ -14,6 +14,25 @@ export async function DeleteRepositoryPointerToBranch(
         apiDomain:string,
         authToken:string,
         branch:string,
-        commitHash:string,
+    }):Promise<void> {
+
+        // Skip deleteing repository pointers in test environment
+        if (isTestEnv()) {
+            return Promise.resolve();
+        }
+
+        const branchName:string = encodeBranchName(opts.branch);
+
+        return requestPromiseWithEnhancedError(`${opts.apiDomain}/code/v/1.0/delete-repository-pointer`, {
+            body: {
+                pointerName: branchName,
+                pointerType: RepositoryPointerType.Branch,
+            },
+            headers: {
+                ...getAuthHeaders(opts.authToken),
+                ...getUserAgentHeaders(),
+            },
+            json: true,
+            method: 'DELETE',
+        }).then(() => undefined);
     }
-)

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/DeleteRepositoryPointerToBranch.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/DeleteRepositoryPointerToBranch.ts
@@ -1,0 +1,19 @@
+import { isTestEnv } from '../../../program/env/isTestEnv';
+import { requestPromiseWithEnhancedError } from '../../../utils/requestPromiseWithEnhancedError';
+import { getAuthHeaders } from './headers/getAuthHeaders';
+import { getUserAgentHeaders } from './headers/getUserAgentHeaders';
+import { encodeBranchName } from './params/encodeBranchName';
+
+export const enum RepositoryPointerType {
+    Branch = 'branch',
+    Tag = 'tag',
+}
+
+export async function DeleteRepositoryPointerToBranch(
+    opts:{
+        apiDomain:string,
+        authToken:string,
+        branch:string,
+        commitHash:string,
+    }
+)

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/DeleteRepositoryPointerToBranch.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/DeleteRepositoryPointerToBranch.ts
@@ -9,30 +9,30 @@ export const enum RepositoryPointerType {
     Tag = 'tag',
 }
 
-export async function DeleteRepositoryPointerToBranch(
+export async function deleteRepositoryPointerToBranch(
     opts:{
-        apiDomain:string,
-        authToken:string,
-        branch:string,
+      apiDomain:string,
+      authToken:string,
+      branch:string,
     }):Promise<void> {
 
         // Skip deleteing repository pointers in test environment
-        if (isTestEnv()) {
-            return Promise.resolve();
-        }
+  if (isTestEnv()) {
+    return Promise.resolve();
+  }
 
-        const branchName:string = encodeBranchName(opts.branch);
+  const branchName:string = encodeBranchName(opts.branch);
 
-        return requestPromiseWithEnhancedError(`${opts.apiDomain}/code/v/1.0/delete-repository-pointer`, {
-            body: {
-                pointerName: branchName,
-                pointerType: RepositoryPointerType.Branch,
-            },
-            headers: {
-                ...getAuthHeaders(opts.authToken),
-                ...getUserAgentHeaders(),
-            },
-            json: true,
-            method: 'DELETE',
-        }).then(() => undefined);
-    }
+  return requestPromiseWithEnhancedError(`${opts.apiDomain}/code/v/1.0/delete-repository-pointer`, {
+    body: {
+      pointerName: branchName,
+      pointerType: RepositoryPointerType.Branch,
+    },
+    headers: {
+      ...getAuthHeaders(opts.authToken),
+      ...getUserAgentHeaders(),
+    },
+    json: true,
+    method: 'DELETE',
+  }).then(() => undefined);
+}

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/DeleteTag.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/DeleteTag.ts
@@ -1,0 +1,36 @@
+import { isTestEnv } from '../../../program/env/isTestEnv';
+import { requestPromiseWithEnhancedError } from '../../../utils/requestPromiseWithEnhancedError';
+import { getAuthHeaders } from './headers/getAuthHeaders';
+import { getUserAgentHeaders } from './headers/getUserAgentHeaders';
+
+
+export const enum RepositoryPointerType {
+    Branch = 'branch',
+    Tag = 'tag',
+}
+
+export async function DeleteTag(
+    opts:{
+        apiDomain:string,
+        authToken:string,
+        tag:string,
+    }):Promise<void> {
+    
+        //Skip updating repository pointers in test environment
+        if (isTestEnv()) {
+            return Promise.resolve();
+        }
+    
+        return requestPromiseWithEnhancedError(`${opts.apiDomain}/code/v/1.0/delete-repository-pointer`, {
+            body: {
+                pointerName: opts.tag,
+                pointerType: RepositoryPointerType.Tag,
+            },
+            headers: {
+                ...getAuthHeaders(opts.authToken),
+                ...getUserAgentHeaders(),
+            },
+            json: true,
+            method: 'DELETE',
+        }).then(() => undefined);
+    }

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/DeleteTag.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/DeleteTag.ts
@@ -3,34 +3,33 @@ import { requestPromiseWithEnhancedError } from '../../../utils/requestPromiseWi
 import { getAuthHeaders } from './headers/getAuthHeaders';
 import { getUserAgentHeaders } from './headers/getUserAgentHeaders';
 
-
 export const enum RepositoryPointerType {
     Branch = 'branch',
     Tag = 'tag',
 }
 
-export async function DeleteTag(
+export async function deleteTag(
     opts:{
-        apiDomain:string,
-        authToken:string,
-        tag:string,
+      apiDomain:string,
+      authToken:string,
+      tag:string,
     }):Promise<void> {
-    
-        //Skip updating repository pointers in test environment
-        if (isTestEnv()) {
-            return Promise.resolve();
-        }
-    
-        return requestPromiseWithEnhancedError(`${opts.apiDomain}/code/v/1.0/delete-repository-pointer`, {
-            body: {
-                pointerName: opts.tag,
-                pointerType: RepositoryPointerType.Tag,
-            },
-            headers: {
-                ...getAuthHeaders(opts.authToken),
-                ...getUserAgentHeaders(),
-            },
-            json: true,
-            method: 'DELETE',
-        }).then(() => undefined);
-    }
+
+ // Skip updating repository pointers in test environment
+  if (isTestEnv()) {
+    return Promise.resolve();
+  }
+
+  return requestPromiseWithEnhancedError(`${opts.apiDomain}/code/v/1.0/delete-repository-pointer`, {
+    body: {
+      pointerName: opts.tag,
+      pointerType: RepositoryPointerType.Tag,
+    },
+    headers: {
+      ...getAuthHeaders(opts.authToken),
+      ...getUserAgentHeaders(),
+    },
+    json: true,
+    method: 'DELETE',
+  }).then(() => undefined);
+}

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/DeleteTag.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/DeleteTag.ts
@@ -1,12 +1,8 @@
+import { RepositoryPointerType } from '../../../../src/common/RepositoryPointerType';
 import { isTestEnv } from '../../../program/env/isTestEnv';
 import { requestPromiseWithEnhancedError } from '../../../utils/requestPromiseWithEnhancedError';
 import { getAuthHeaders } from './headers/getAuthHeaders';
 import { getUserAgentHeaders } from './headers/getUserAgentHeaders';
-
-export const enum RepositoryPointerType {
-    Branch = 'branch',
-    Tag = 'tag',
-}
 
 export async function deleteTag(
     opts:{
@@ -20,7 +16,7 @@ export async function deleteTag(
     return Promise.resolve();
   }
 
-  return requestPromiseWithEnhancedError(`${opts.apiDomain}/code/v/1.0/delete-repository-pointer`, {
+  await requestPromiseWithEnhancedError(`${opts.apiDomain}/code/v/1.0/delete-repository-pointer`, {
     body: {
       pointerName: opts.tag,
       pointerType: RepositoryPointerType.Tag,
@@ -31,5 +27,5 @@ export async function deleteTag(
     },
     json: true,
     method: 'DELETE',
-  }).then(() => undefined);
+  });
 }

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/getDefaultApiDomain.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/getDefaultApiDomain.ts
@@ -1,0 +1,10 @@
+import { isDevelopmentEnv } from '../../../../src/program/env/isDevelopmentEnv';
+import { isTestEnv } from '../../../../src/program/env/isTestEnv';
+
+const TEST_UXPIN_API_DOMAIN:string = '0.0.0.0';
+
+export function getDefaultApiDomain(domain:string):string {
+  return isTestEnv() || isDevelopmentEnv()
+          ? process.env.UXPIN_API_DOMAIN || TEST_UXPIN_API_DOMAIN
+          : `api.${domain}`;
+}

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/updateRepositoryPointerToBranch.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/updateRepositoryPointerToBranch.ts
@@ -1,13 +1,9 @@
+import { RepositoryPointerType } from '../../../../src/common/RepositoryPointerType';
 import { isTestEnv } from '../../../program/env/isTestEnv';
 import { requestPromiseWithEnhancedError } from '../../../utils/requestPromiseWithEnhancedError';
 import { getAuthHeaders } from './headers/getAuthHeaders';
 import { getUserAgentHeaders } from './headers/getUserAgentHeaders';
 import { encodeBranchName } from './params/encodeBranchName';
-
-export const enum RepositoryPointerType {
-  Branch = 'branch',
-  Tag = 'tag',
-}
 
 export async function updateRepositoryPointerToBranch(
   opts:{

--- a/packages/uxpin-merge-cli/src/program/args/ProgramArgs.ts
+++ b/packages/uxpin-merge-cli/src/program/args/ProgramArgs.ts
@@ -20,6 +20,7 @@ export type ProgramArgs = DumpProgramArgs
     | ExperimentProgramArgs
     | InitProgramArgs
     | PushProgramArgs
+    | DeleteVersionArgs
     | GeneratePresetsProgramArgs
     | ServerProgramArgs
     | SummaryProgramArgs;
@@ -61,6 +62,14 @@ export interface PushProgramArgs {
   // https://github.com/UXPin/uxpin-merge-tools/issues/206
   branch?:string;
   tag?:string;
+}
+
+export interface DeleteVersionArgs {
+  command:Command.DELETE_VERSION;
+  token?:string;
+  uxpinDomain?:string;
+  branch?:string,
+  tag?:string,
 }
 
 export interface GeneratePresetsProgramArgs {

--- a/packages/uxpin-merge-cli/src/program/args/ProgramArgs.ts
+++ b/packages/uxpin-merge-cli/src/program/args/ProgramArgs.ts
@@ -67,6 +67,8 @@ export interface PushProgramArgs {
 export interface DeleteVersionArgs {
   command:Command.DELETE_VERSION;
   token?:string;
+  cwd:string;
+  config?:string;
   uxpinDomain?:string;
   branch?:string,
   tag?:string,

--- a/packages/uxpin-merge-cli/src/program/args/ProgramArgs.ts
+++ b/packages/uxpin-merge-cli/src/program/args/ProgramArgs.ts
@@ -70,8 +70,8 @@ export interface DeleteVersionArgs {
   cwd:string;
   config?:string;
   uxpinDomain?:string;
-  branch?:string,
-  tag?:string,
+  branch?:string;
+  tag?:string;
 }
 
 export interface GeneratePresetsProgramArgs {

--- a/packages/uxpin-merge-cli/src/program/args/getProgramArgs.ts
+++ b/packages/uxpin-merge-cli/src/program/args/getProgramArgs.ts
@@ -39,6 +39,11 @@ const defaultArgs:{ [key in Command]:ProgramArgs } = {
     token: process.env.UXPIN_AUTH_TOKEN,
     uxpinDomain: DEFAULT_UXPIN_DOMAIN,
   },
+  [Command.DELETE_VERSION]: {
+    command: Command.DELETE_VERSION,
+    token: process.env.UXPIN_AUTH_TOKEN,
+    uxpinDomain: DEFAULT_UXPIN_DOMAIN,
+  },
   [Command.SERVER]: {
     command: Command.SERVER,
     config: DEFAULT_CONFIG_PATH,

--- a/packages/uxpin-merge-cli/src/program/args/getProgramArgs.ts
+++ b/packages/uxpin-merge-cli/src/program/args/getProgramArgs.ts
@@ -87,7 +87,6 @@ function getCLIArgs(program:RawProgramArgs, command:Command):ProgramArgs {
 function getCommandArgs(program:RawProgramArgs, command:Command):ProgramArgs | {} {
   const commanderStatic:CommanderStatic = (program.args || [])
     .find(isArgKnownCommand([command])) as CommanderStatic;
-
   if (!commanderStatic) {
     return {};
   }

--- a/packages/uxpin-merge-cli/src/program/args/getProgramArgs.ts
+++ b/packages/uxpin-merge-cli/src/program/args/getProgramArgs.ts
@@ -41,6 +41,8 @@ const defaultArgs:{ [key in Command]:ProgramArgs } = {
   },
   [Command.DELETE_VERSION]: {
     command: Command.DELETE_VERSION,
+    config: DEFAULT_CONFIG_PATH,
+    cwd: process.cwd(),
     token: process.env.UXPIN_AUTH_TOKEN,
     uxpinDomain: DEFAULT_UXPIN_DOMAIN,
   },

--- a/packages/uxpin-merge-cli/src/program/command/Command.ts
+++ b/packages/uxpin-merge-cli/src/program/command/Command.ts
@@ -4,6 +4,7 @@ export enum Command {
   INIT = 'init',
   GENERATE_PRESETS = 'generate-presets',
   PUSH = 'push',
+  DELETE_VERSION = 'delete-version',
   SERVER = 'server',
   SUMMARY = 'summary',
 }

--- a/packages/uxpin-merge-cli/src/program/command/delete_version/getDeleteOptions.ts
+++ b/packages/uxpin-merge-cli/src/program/command/delete_version/getDeleteOptions.ts
@@ -1,16 +1,31 @@
 import { DeleteOptions } from "../../../steps/deleting/DeleteOptions";
 import { DeleteVersionArgs } from "../../args/ProgramArgs";
+import { isTestEnv } from "../../../program/env/isTestEnv";
+import { isDevelopmentEnv } from "../../../program/env/isDevelopmentEnv";
+import { getTempDirPath } from "../../args/providers/paths/getTempDirPath";
+import { getProjectRoot } from "../../args/providers/paths/getProjectRoot";
+
+const TEST_UXPIN_API_DOMAIN:string = '0.0.0.0';
+
+function getDefaultApiDomain(domain:string):string {
+    return isTestEnv() || isDevelopmentEnv()
+        ? process.env.UXPIN_API_DOMAIN || TEST_UXPIN_API_DOMAIN
+        : `api.${domain}`;
+}
 
 export function getDeleteOptions(args:DeleteVersionArgs):DeleteOptions {
     const { token, uxpinDomain, branch, tag } = args;
 
     return {
         branch,
+        projectRoot: getProjectRoot(args),
         tag,
+        uxpinDirPath: getTempDirPath(args),
+        uxpinApiDomain: getDefaultApiDomain(uxpinDomain!),
         uxpinDomain,
         token,
     };
 }
 
-export type DeleteArgs = Pick<DeleteVersionArgs, 'token' | 'uxpinDomain'
+export type DeleteArgs = Pick<DeleteVersionArgs, 'cwd' | 'token' | 'uxpinDomain'
 | 'branch' | 'tag'>;

--- a/packages/uxpin-merge-cli/src/program/command/delete_version/getDeleteOptions.ts
+++ b/packages/uxpin-merge-cli/src/program/command/delete_version/getDeleteOptions.ts
@@ -1,30 +1,30 @@
-import { DeleteOptions } from "../../../steps/deleting/DeleteOptions";
-import { DeleteVersionArgs } from "../../args/ProgramArgs";
-import { isTestEnv } from "../../../program/env/isTestEnv";
-import { isDevelopmentEnv } from "../../../program/env/isDevelopmentEnv";
-import { getTempDirPath } from "../../args/providers/paths/getTempDirPath";
-import { getProjectRoot } from "../../args/providers/paths/getProjectRoot";
+import { isDevelopmentEnv } from '../../../program/env/isDevelopmentEnv';
+import { isTestEnv } from '../../../program/env/isTestEnv';
+import { DeleteOptions } from '../../../steps/deleting/DeleteOptions';
+import { DeleteVersionArgs } from '../../args/ProgramArgs';
+import { getProjectRoot } from '../../args/providers/paths/getProjectRoot';
+import { getTempDirPath } from '../../args/providers/paths/getTempDirPath';
 
 const TEST_UXPIN_API_DOMAIN:string = '0.0.0.0';
 
 function getDefaultApiDomain(domain:string):string {
-    return isTestEnv() || isDevelopmentEnv()
+  return isTestEnv() || isDevelopmentEnv()
         ? process.env.UXPIN_API_DOMAIN || TEST_UXPIN_API_DOMAIN
         : `api.${domain}`;
 }
 
 export function getDeleteOptions(args:DeleteVersionArgs):DeleteOptions {
-    const { token, uxpinDomain, branch, tag } = args;
+  const { token, uxpinDomain, branch, tag } = args;
 
-    return {
-        branch,
-        projectRoot: getProjectRoot(args),
-        tag,
-        uxpinDirPath: getTempDirPath(args),
-        uxpinApiDomain: getDefaultApiDomain(uxpinDomain!),
-        uxpinDomain,
-        token,
-    };
+  return {
+    branch,
+    projectRoot: getProjectRoot(args),
+    tag,
+    token,
+    uxpinApiDomain: getDefaultApiDomain(uxpinDomain!),
+    uxpinDirPath: getTempDirPath(args),
+    uxpinDomain,
+  };
 }
 
 export type DeleteArgs = Pick<DeleteVersionArgs, 'cwd' | 'token' | 'uxpinDomain'

--- a/packages/uxpin-merge-cli/src/program/command/delete_version/getDeleteOptions.ts
+++ b/packages/uxpin-merge-cli/src/program/command/delete_version/getDeleteOptions.ts
@@ -1,17 +1,8 @@
-import { isDevelopmentEnv } from '../../../program/env/isDevelopmentEnv';
-import { isTestEnv } from '../../../program/env/isTestEnv';
+import { getDefaultApiDomain } from '../../../../src/common/services/UXPin/getDefaultApiDomain';
 import { DeleteOptions } from '../../../steps/deleting/DeleteOptions';
 import { DeleteVersionArgs } from '../../args/ProgramArgs';
 import { getProjectRoot } from '../../args/providers/paths/getProjectRoot';
 import { getTempDirPath } from '../../args/providers/paths/getTempDirPath';
-
-const TEST_UXPIN_API_DOMAIN:string = '0.0.0.0';
-
-function getDefaultApiDomain(domain:string):string {
-  return isTestEnv() || isDevelopmentEnv()
-        ? process.env.UXPIN_API_DOMAIN || TEST_UXPIN_API_DOMAIN
-        : `api.${domain}`;
-}
 
 export function getDeleteOptions(args:DeleteVersionArgs):DeleteOptions {
   const { token, uxpinDomain, branch, tag } = args;

--- a/packages/uxpin-merge-cli/src/program/command/delete_version/getDeleteOptions.ts
+++ b/packages/uxpin-merge-cli/src/program/command/delete_version/getDeleteOptions.ts
@@ -1,0 +1,16 @@
+import { DeleteOptions } from "../../../steps/deleting/DeleteOptions";
+import { DeleteVersionArgs } from "../../args/ProgramArgs";
+
+export function getDeleteOptions(args:DeleteVersionArgs):DeleteOptions {
+    const { token, uxpinDomain, branch, tag } = args;
+
+    return {
+        branch,
+        tag,
+        uxpinDomain,
+        token,
+    };
+}
+
+export type DeleteArgs = Pick<DeleteVersionArgs, 'token' | 'uxpinDomain'
+| 'branch' | 'tag'>;

--- a/packages/uxpin-merge-cli/src/program/command/delete_version/getDeleteVersionCommandSteps.ts
+++ b/packages/uxpin-merge-cli/src/program/command/delete_version/getDeleteVersionCommandSteps.ts
@@ -1,13 +1,13 @@
-import { DeleteVersionArgs } from "../../args/ProgramArgs";
+import { DeleteOptions } from '../../../steps/deleting/DeleteOptions';
+import { DeleteVersionArgs } from '../../args/ProgramArgs';
 import { Step } from '../Step';
-import { DeleteOptions } from "../../../steps/deleting/DeleteOptions";
-import { getDeleteOptions } from "./getDeleteOptions";
-import { DeleteRepositoryPointer } from "./steps/DeleteRepositoryPointer";
+import { getDeleteOptions } from './getDeleteOptions';
+import { deleteRepositoryPointer } from './steps/DeleteRepositoryPointer';
 
 export function getDeleteVersionCommandSteps(args:DeleteVersionArgs):Step[] {
-    const deleteOptions:DeleteOptions = getDeleteOptions(args);
+  const deleteOptions:DeleteOptions = getDeleteOptions(args);
 
-    return [
-        { exec: DeleteRepositoryPointer(deleteOptions), shouldRun: true }
-    ]
+  return [
+        { exec: deleteRepositoryPointer(deleteOptions), shouldRun: true },
+  ];
 }

--- a/packages/uxpin-merge-cli/src/program/command/delete_version/getDeleteVersionCommandSteps.ts
+++ b/packages/uxpin-merge-cli/src/program/command/delete_version/getDeleteVersionCommandSteps.ts
@@ -2,11 +2,12 @@ import { DeleteVersionArgs } from "../../args/ProgramArgs";
 import { Step } from '../Step';
 import { DeleteOptions } from "../../../steps/deleting/DeleteOptions";
 import { getDeleteOptions } from "./getDeleteOptions";
+import { DeleteRepositoryPointer } from "./steps/DeleteRepositoryPointer";
 
 export function getDeleteVersionCommandSteps(args:DeleteVersionArgs):Step[] {
     const deleteOptions:DeleteOptions = getDeleteOptions(args);
 
     return [
-        { exec: }
+        { exec: DeleteRepositoryPointer(deleteOptions), shouldRun: true }
     ]
 }

--- a/packages/uxpin-merge-cli/src/program/command/delete_version/getDeleteVersionCommandSteps.ts
+++ b/packages/uxpin-merge-cli/src/program/command/delete_version/getDeleteVersionCommandSteps.ts
@@ -1,0 +1,12 @@
+import { DeleteVersionArgs } from "../../args/ProgramArgs";
+import { Step } from '../Step';
+import { DeleteOptions } from "../../../steps/deleting/DeleteOptions";
+import { getDeleteOptions } from "./getDeleteOptions";
+
+export function getDeleteVersionCommandSteps(args:DeleteVersionArgs):Step[] {
+    const deleteOptions:DeleteOptions = getDeleteOptions(args);
+
+    return [
+        { exec: }
+    ]
+}

--- a/packages/uxpin-merge-cli/src/program/command/delete_version/steps/DeleteRepositoryPointer.ts
+++ b/packages/uxpin-merge-cli/src/program/command/delete_version/steps/DeleteRepositoryPointer.ts
@@ -3,19 +3,42 @@ import { getApiDomain } from '../../../../common/services/UXPin/getApiDomain';
 import { DeleteRepositoryPointerToBranch } from '../../../../common/services/UXPin/DeleteRepositoryPointerToBranch';
 import { DeleteOptions } from '../../../../steps/deleting/DeleteOptions';
 import { DSMetadata } from '../../../../program/DSMeta';
+import { printError, printLine } from '../../../../utils/console/printLine';
 import { VCSDetails } from '../../../../steps/serialization/DesignSystemSnapshot';
+import { PrintColor } from '../../../../../src/utils/console/PrintOptions';
+import { DEFAULT_BRANCH_NAME } from '../../../../../src/common/constants';
 
 export function DeleteRepositoryPointer(deleteOptions:DeleteOptions) {
     return async (designSystem:DSMetadata) => {
         const apiDomain:string = getApiDomain(deleteOptions.uxpinApiDomain!);
         const authToken:string = deleteOptions.token!;
         const vcsDetails:VCSDetails = designSystem.result.vcs;
-        const branch:string | undefined = vcsDetails && vcsDetails.branchName;
+        const commitHash:string = vcsDetails.commitHash;
+        const branch:string | undefined = vcsDetails && vcsDetails.branchName !== DEFAULT_BRANCH_NAME ? vcsDetails.branchName : undefined;
         const tag:string | undefined = deleteOptions.tag;
 
+        if (!tag && !branch) {
+            printError(
+                `🛑 Please specify --branch or --tag and the name of the version you would like to delete.`
+                );
+        }
+
         if (tag) {
-            await DeleteTagWithPrintMessage({apiDomain, authToken, tag})
-            
+            await DeleteTagWithPrintMessage({
+                apiDomain, 
+                authToken, 
+                commitHash, 
+                tag,
+            });
+        }
+
+        if (branch) {
+            await DeleteRepositoryPointerWithPrintMessage({
+                apiDomain,
+                authToken,
+                branch,
+                commitHash,
+            })
         }
     }
 }
@@ -23,12 +46,26 @@ export function DeleteRepositoryPointer(deleteOptions:DeleteOptions) {
 async function DeleteTagWithPrintMessage(opts:{
     apiDomain:string,
     authToken:string,
+    commitHash:string,
     tag:string,
 }):Promise<void> {
-    try {
-        console.log('delete tag!')
         await DeleteTag(opts);
-    } catch (error) {
-        console.log('oh no tag error!')
-    }
+        printLine(
+            `🏷️  Library tag version [${opts.tag}] at commit hash [${opts.commitHash}] has been deleted.`,
+            {color: PrintColor.YELLOW}
+        );
+}
+
+async function DeleteRepositoryPointerWithPrintMessage(opts:{
+    apiDomain:string,
+    authToken:string,
+    branch:string,
+    commitHash:string,
+}):Promise<void> {
+    
+    await DeleteRepositoryPointerToBranch(opts);
+    printLine(
+        `Library branch version [${opts.branch}] at commit hash [${opts.commitHash}] has been deleted.`,
+        {color: PrintColor.YELLOW}
+    )
 }

--- a/packages/uxpin-merge-cli/src/program/command/delete_version/steps/DeleteRepositoryPointer.ts
+++ b/packages/uxpin-merge-cli/src/program/command/delete_version/steps/DeleteRepositoryPointer.ts
@@ -49,11 +49,19 @@ async function DeleteTagWithPrintMessage(opts:{
     commitHash:string,
     tag:string,
 }):Promise<void> {
+    try {
         await DeleteTag(opts);
         printLine(
-            `🏷️  Library tag version [${opts.tag}] at commit hash [${opts.commitHash}] has been deleted.`,
+            `🏷️  Library tag version [${opts.tag}] has been deleted.`,
             {color: PrintColor.YELLOW}
         );
+    } catch(error) {
+        printLine(
+        `🛑 There was an error while deleting tag [${opts.tag}] at commit hash [${opts.commitHash}]`,
+            { color: PrintColor.RED },
+        );
+        throw new Error(error.message);
+    }      
 }
 
 async function DeleteRepositoryPointerWithPrintMessage(opts:{
@@ -62,10 +70,17 @@ async function DeleteRepositoryPointerWithPrintMessage(opts:{
     branch:string,
     commitHash:string,
 }):Promise<void> {
-    
+    try { 
     await DeleteRepositoryPointerToBranch(opts);
     printLine(
-        `Library branch version [${opts.branch}] at commit hash [${opts.commitHash}] has been deleted.`,
+        `Library branch version [${opts.branch}] has been deleted.`,
         {color: PrintColor.YELLOW}
-    )
+    );
+    } catch(error) {
+        printLine(
+        `🛑 There was an error while deleting branch [${opts.branch}]`,
+        { color: PrintColor.RED },
+        );
+        throw new Error(error.message);
+    }
 }

--- a/packages/uxpin-merge-cli/src/program/command/delete_version/steps/DeleteRepositoryPointer.ts
+++ b/packages/uxpin-merge-cli/src/program/command/delete_version/steps/DeleteRepositoryPointer.ts
@@ -1,0 +1,34 @@
+import { DeleteTag } from '../../../../common/services/UXPin/DeleteTag';
+import { getApiDomain } from '../../../../common/services/UXPin/getApiDomain';
+import { DeleteRepositoryPointerToBranch } from '../../../../common/services/UXPin/DeleteRepositoryPointerToBranch';
+import { DeleteOptions } from '../../../../steps/deleting/DeleteOptions';
+import { DSMetadata } from '../../../../program/DSMeta';
+import { VCSDetails } from '../../../../steps/serialization/DesignSystemSnapshot';
+
+export function DeleteRepositoryPointer(deleteOptions:DeleteOptions) {
+    return async (designSystem:DSMetadata) => {
+        const apiDomain:string = getApiDomain(deleteOptions.uxpinApiDomain!);
+        const authToken:string = deleteOptions.token!;
+        const vcsDetails:VCSDetails = designSystem.result.vcs;
+        const branch:string | undefined = vcsDetails && vcsDetails.branchName;
+        const tag:string | undefined = deleteOptions.tag;
+
+        if (tag) {
+            await DeleteTagWithPrintMessage({apiDomain, authToken, tag})
+            
+        }
+    }
+}
+
+async function DeleteTagWithPrintMessage(opts:{
+    apiDomain:string,
+    authToken:string,
+    tag:string,
+}):Promise<void> {
+    try {
+        console.log('delete tag!')
+        await DeleteTag(opts);
+    } catch (error) {
+        console.log('oh no tag error!')
+    }
+}

--- a/packages/uxpin-merge-cli/src/program/command/delete_version/steps/DeleteRepositoryPointer.ts
+++ b/packages/uxpin-merge-cli/src/program/command/delete_version/steps/DeleteRepositoryPointer.ts
@@ -1,86 +1,94 @@
-import { DeleteTag } from '../../../../common/services/UXPin/DeleteTag';
-import { getApiDomain } from '../../../../common/services/UXPin/getApiDomain';
-import { DeleteRepositoryPointerToBranch } from '../../../../common/services/UXPin/DeleteRepositoryPointerToBranch';
-import { DeleteOptions } from '../../../../steps/deleting/DeleteOptions';
-import { DSMetadata } from '../../../../program/DSMeta';
-import { printError, printLine } from '../../../../utils/console/printLine';
-import { VCSDetails } from '../../../../steps/serialization/DesignSystemSnapshot';
-import { PrintColor } from '../../../../../src/utils/console/PrintOptions';
 import { DEFAULT_BRANCH_NAME } from '../../../../../src/common/constants';
+import { PrintColor } from '../../../../../src/utils/console/PrintOptions';
+import { deleteRepositoryPointerToBranch } from '../../../../common/services/UXPin/DeleteRepositoryPointerToBranch';
+import { deleteTag } from '../../../../common/services/UXPin/DeleteTag';
+import { getApiDomain } from '../../../../common/services/UXPin/getApiDomain';
+import { DSMetadata } from '../../../../program/DSMeta';
+import { DeleteOptions } from '../../../../steps/deleting/DeleteOptions';
+import { VCSDetails } from '../../../../steps/serialization/DesignSystemSnapshot';
+import { printError, printLine } from '../../../../utils/console/printLine';
+import { StepExecutor } from '../../Step';
 
-export function DeleteRepositoryPointer(deleteOptions:DeleteOptions) {
-    return async (designSystem:DSMetadata) => {
-        const apiDomain:string = getApiDomain(deleteOptions.uxpinApiDomain!);
-        const authToken:string = deleteOptions.token!;
-        const vcsDetails:VCSDetails = designSystem.result.vcs;
-        const commitHash:string = vcsDetails.commitHash;
-        const branch:string | undefined = vcsDetails && vcsDetails.branchName !== DEFAULT_BRANCH_NAME ? vcsDetails.branchName : undefined;
-        const tag:string | undefined = deleteOptions.tag;
+export function deleteRepositoryPointer(deleteOptions:DeleteOptions):StepExecutor {
+  return async (designSystem:DSMetadata) => {
+    const apiDomain:string = getApiDomain(deleteOptions.uxpinApiDomain!);
+    const authToken:string = deleteOptions.token!;
+    const vcsDetails:VCSDetails = designSystem.result.vcs;
+    const commitHash:string = vcsDetails.commitHash;
+    const branch:string | undefined = vcsDetails && vcsDetails.branchName !== DEFAULT_BRANCH_NAME
+    ? vcsDetails.branchName
+    : undefined;
+    const tag:string | undefined = deleteOptions.tag;
 
-        if (!tag && !branch) {
-            printError(
-                `🛑 Please specify --branch or --tag and the name of the version you would like to delete.`
+    if (!tag && !branch) {
+      printError(
+      `🛑 Please specify --branch or --tag and the name of the version you would like to delete.`,
                 );
-        }
-
-        if (tag) {
-            await DeleteTagWithPrintMessage({
-                apiDomain, 
-                authToken, 
-                commitHash, 
-                tag,
-            });
-        }
-
-        if (branch) {
-            await DeleteRepositoryPointerWithPrintMessage({
-                apiDomain,
-                authToken,
-                branch,
-                commitHash,
-            })
-        }
+      return designSystem;
     }
+
+    if (tag) {
+      await deleteTagWithPrintMessage({
+        apiDomain,
+        authToken,
+        commitHash,
+        tag,
+      });
+      return designSystem;
+    }
+
+    if (branch) {
+      await deleteRepositoryPointerWithPrintMessage({
+        apiDomain,
+        authToken,
+        branch,
+        commitHash,
+      });
+      return designSystem;
+    }
+
+    return designSystem;
+  };
 }
 
-async function DeleteTagWithPrintMessage(opts:{
-    apiDomain:string,
-    authToken:string,
-    commitHash:string,
-    tag:string,
+async function deleteTagWithPrintMessage(opts:{
+  apiDomain:string,
+  authToken:string,
+  commitHash:string,
+  tag:string,
 }):Promise<void> {
-    try {
-        await DeleteTag(opts);
-        printLine(
+  try {
+    await deleteTag(opts);
+    printLine(
             `🏷️  Library tag version [${opts.tag}] has been deleted.`,
-            {color: PrintColor.YELLOW}
+            { color: PrintColor.YELLOW },
         );
-    } catch(error) {
-        printLine(
+  } catch (error) {
+    printLine(
         `🛑 There was an error while deleting tag [${opts.tag}] at commit hash [${opts.commitHash}]`,
             { color: PrintColor.RED },
         );
-        throw new Error(error.message);
-    }      
+    throw new Error(error.message);
+  }
 }
 
-async function DeleteRepositoryPointerWithPrintMessage(opts:{
-    apiDomain:string,
-    authToken:string,
-    branch:string,
-    commitHash:string,
+async function deleteRepositoryPointerWithPrintMessage(opts:{
+  apiDomain:string,
+  authToken:string,
+  branch:string,
+  commitHash:string,
 }):Promise<void> {
-    try { 
-    await DeleteRepositoryPointerToBranch(opts);
+  try {
+    await deleteRepositoryPointerToBranch(opts);
     printLine(
         `Library branch version [${opts.branch}] has been deleted.`,
-        {color: PrintColor.YELLOW}
+        { color: PrintColor.YELLOW },
     );
-    } catch(error) {
-        printLine(
+  } catch (error) {
+    printLine(
         `🛑 There was an error while deleting branch [${opts.branch}]`,
         { color: PrintColor.RED },
         );
-        throw new Error(error.message);
-    }
+    throw new Error(error.message);
+  }
 }

--- a/packages/uxpin-merge-cli/src/program/command/delete_version/steps/DeleteRepositoryPointer.ts
+++ b/packages/uxpin-merge-cli/src/program/command/delete_version/steps/DeleteRepositoryPointer.ts
@@ -20,6 +20,13 @@ export function deleteRepositoryPointer(deleteOptions:DeleteOptions):StepExecuto
     : undefined;
     const tag:string | undefined = deleteOptions.tag;
 
+    if (tag && branch) {
+      printError(
+      `🛑 Please specify --branch or --tag. Only one option is required.`,
+                );
+      return designSystem;
+    }
+
     if (!tag && !branch) {
       printError(
       `🛑 Please specify --branch or --tag and the name of the version you would like to delete.`,

--- a/packages/uxpin-merge-cli/src/program/command/getSteps.ts
+++ b/packages/uxpin-merge-cli/src/program/command/getSteps.ts
@@ -5,6 +5,7 @@ import { getExperimentationCommandSteps } from './experimentation/getExperimenta
 import { getGeneratePresetsCommandSteps } from './generate_presets/getGeneratePresetsCommandSteps';
 import { getInitCommandSteps } from './init/getInitCommandSteps';
 import { getPushCommandSteps } from './push/getPushCommandSteps';
+import { getDeleteVersionCommandSteps } from './delete_version/getDeleteVersionCommandSteps';
 import { getServerCommandSteps } from './server/getServerCommandSteps';
 import { Step } from './Step';
 import { getSummaryCommandSteps } from './summary/getSummaryCommandSteps';
@@ -27,7 +28,7 @@ export function getSteps(args:ProgramArgs):Step[] {
       return getPushCommandSteps(args);
 
     case Command.DELETE_VERSION:
-      //create method for deleting tag or branch  
+      return getDeleteVersionCommandSteps(args);
 
     case Command.SERVER:
       return getServerCommandSteps(args);

--- a/packages/uxpin-merge-cli/src/program/command/getSteps.ts
+++ b/packages/uxpin-merge-cli/src/program/command/getSteps.ts
@@ -1,11 +1,11 @@
 import { ProgramArgs } from '../args/ProgramArgs';
 import { Command } from './Command';
+import { getDeleteVersionCommandSteps } from './delete_version/getDeleteVersionCommandSteps';
 import { getDumpCommandSteps } from './dump/getDumpCommandSteps';
 import { getExperimentationCommandSteps } from './experimentation/getExperimentationCommandSteps';
 import { getGeneratePresetsCommandSteps } from './generate_presets/getGeneratePresetsCommandSteps';
 import { getInitCommandSteps } from './init/getInitCommandSteps';
 import { getPushCommandSteps } from './push/getPushCommandSteps';
-import { getDeleteVersionCommandSteps } from './delete_version/getDeleteVersionCommandSteps';
 import { getServerCommandSteps } from './server/getServerCommandSteps';
 import { Step } from './Step';
 import { getSummaryCommandSteps } from './summary/getSummaryCommandSteps';

--- a/packages/uxpin-merge-cli/src/program/command/getSteps.ts
+++ b/packages/uxpin-merge-cli/src/program/command/getSteps.ts
@@ -26,6 +26,9 @@ export function getSteps(args:ProgramArgs):Step[] {
     case Command.PUSH:
       return getPushCommandSteps(args);
 
+    case Command.DELETE_VERSION:
+      //create method for deleting tag or branch  
+
     case Command.SERVER:
       return getServerCommandSteps(args);
 

--- a/packages/uxpin-merge-cli/src/program/command/push/getBuildOptions.ts
+++ b/packages/uxpin-merge-cli/src/program/command/push/getBuildOptions.ts
@@ -1,17 +1,8 @@
-import { isDevelopmentEnv } from '../../../program/env/isDevelopmentEnv';
-import { isTestEnv } from '../../../program/env/isTestEnv';
+import { getDefaultApiDomain } from '../../../../src/common/services/UXPin/getDefaultApiDomain';
 import { BuildOptions } from '../../../steps/building/BuildOptions';
 import { PushProgramArgs } from '../../args/ProgramArgs';
 import { getProjectRoot } from '../../args/providers/paths/getProjectRoot';
 import { getTempDirPath } from '../../args/providers/paths/getTempDirPath';
-
-const TEST_UXPIN_API_DOMAIN:string = '0.0.0.0';
-
-function getDefaultApiDomain(domain:string):string {
-  return isTestEnv() || isDevelopmentEnv()
-    ? process.env.UXPIN_API_DOMAIN || TEST_UXPIN_API_DOMAIN
-    : `api.${domain}`;
-}
 
 export function getBuildOptions(args:BuildProgramArgs):BuildOptions {
   const { token, uxpinDomain, webpackConfig, wrapper, branch, tag } = args;

--- a/packages/uxpin-merge-cli/src/steps/deleting/DeleteOptions.ts
+++ b/packages/uxpin-merge-cli/src/steps/deleting/DeleteOptions.ts
@@ -1,6 +1,9 @@
 export interface DeleteOptions {
     token?:string;
+    projectRoot:string;
+    uxpinDirPath:string;
     uxpinDomain?:string;
+    uxpinApiDomain?:string;
     branch?:string;
     tag?:string;
 }

--- a/packages/uxpin-merge-cli/src/steps/deleting/DeleteOptions.ts
+++ b/packages/uxpin-merge-cli/src/steps/deleting/DeleteOptions.ts
@@ -1,0 +1,6 @@
+export interface DeleteOptions {
+    token?:string;
+    uxpinDomain?:string;
+    branch?:string;
+    tag?:string;
+}

--- a/packages/uxpin-merge-cli/src/steps/deleting/DeleteOptions.ts
+++ b/packages/uxpin-merge-cli/src/steps/deleting/DeleteOptions.ts
@@ -1,9 +1,9 @@
 export interface DeleteOptions {
-    token?:string;
-    projectRoot:string;
-    uxpinDirPath:string;
-    uxpinDomain?:string;
-    uxpinApiDomain?:string;
-    branch?:string;
-    tag?:string;
+  token?:string;
+  projectRoot:string;
+  uxpinDirPath:string;
+  uxpinDomain?:string;
+  uxpinApiDomain?:string;
+  branch?:string;
+  tag?:string;
 }

--- a/packages/uxpin-merge-cli/src/steps/experimentation/server/handler/code/GetRepositoryPointerDefaultHandler.ts
+++ b/packages/uxpin-merge-cli/src/steps/experimentation/server/handler/code/GetRepositoryPointerDefaultHandler.ts
@@ -1,15 +1,11 @@
 import { IncomingMessage, ServerResponse } from 'http';
 import { OK } from 'http-status-codes';
+import { RepositoryPointerType } from '../../../../../../src/common/RepositoryPointerType';
 import { DEFAULT_BRANCH_NAME } from '../../../../../common/constants';
 import { getAccessControlHeaders } from '../../headers/getAccessControlHeaders';
 import { getNoCacheHeaders } from '../../headers/getNoCacheHeaders';
 import { ExperimentationServerContext } from '../../startExperimentationServer';
 import { RequestHandler } from '../RequestHandler';
-
-export const enum RepositoryPointerType {
-  Branch = 'branch',
-  Tag = 'tag',
-}
 
 export interface RepoPointerNameAndType {
   name:string;


### PR DESCRIPTION
CLI component for this issue [issue](https://github.com/UXPin/uxpin-issues/issues/475)

- [x] CLI: Add a new `delete-version` command to the with `--tag` and `--branch` options
- [x] CLI: Specifying a tag or branch will delete the selected version 
- [x] CLI: Throw error if no option is specified.
- [x] CLI: Throw error if both options are specified.  

The structure of this command closely follows the structure of the `push` command and a previous PR for creating tags [#282](https://github.com/UXPin/uxpin-merge-tools/pull/282)

## Example of successfully deleting tag:

```
$ @uxpin delete-version --token TOKEN --branch feature-branch-2 --tag 2.1

🏷️ Library tag version [2.1] has been deleted.
```
## Example of successfully deleting branch:

```
$ @uxpin delete-version --token TOKEN --branch feature-branch-2  

Library branch version [testbranch1] has been deleted.
```
## Example of not specifying an option:

```
$ @uxpin delete-version --token TOKEN

🛑 Please specify --branch or --tag and the name of the version you would like to delete.
```
