### PR TITLE
Ignore generated files when running ESLint

### DIFF
--- a/packages/uxpin-merge-cli/.eslintignore
+++ b/packages/uxpin-merge-cli/.eslintignore
@@ -1,0 +1,2 @@
+# Ignore files generated automatically
+/src/types.d.ts


### PR DESCRIPTION
## Goal

Fix the error about `uxpin-merge-tools/packages/uxpin-merge-cli/src/types.d.ts` file when running ESLint

The reason: this file is generated automatically. I'm not sure exactly when because I didn't have this issue when I set up everything, see https://github.com/UXPin/uxpin-merge-tools/pull/323

![image](https://user-images.githubusercontent.com/5546996/195755012-92d984e7-c23d-4fdf-982f-d28b3586563e.png)

## How to check

Run `make check-lint-errors` => no error should be displayed