### PR TITLE
Resolve typescript path aliases

### DIFF
--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/context/getSerializationContext.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/context/getSerializationContext.ts
@@ -1,6 +1,7 @@
 import * as ts from 'typescript';
 import { ComponentImplementationInfo } from '../../../../../discovery/component/ComponentInfo';
 import { findComponentFile } from '../component/findComponentFile';
+import { readFileSync } from 'fs-extra';
 
 export interface TSSerializationContext {
   checker: ts.TypeChecker;
@@ -15,6 +16,7 @@ export function getSerializationContext(component: ComponentImplementationInfo):
     jsx: ts.JsxEmit.React,
     module: ts.ModuleKind.CommonJS,
     target: ts.ScriptTarget.ES2015,
+    paths: getTypesciptPathAliases(),
   });
 
   const file: ts.SourceFile | undefined = findComponentFile(program, path);
@@ -28,4 +30,20 @@ export function getSerializationContext(component: ComponentImplementationInfo):
     file,
     program,
   };
+}
+
+function getTypesciptPathAliases(): ts.MapLike<string[]> | undefined {
+  let paths;
+
+  try {
+    const configFile = readFileSync('tsconfig.json', { encoding: 'utf8' });
+    const config = JSON.parse(configFile) as { compilerOptions: ts.CompilerOptions };
+    if (config.compilerOptions.paths) {
+      paths = config.compilerOptions.paths;
+    }
+  } catch (e) {
+    // ignore error
+  }
+
+  return paths;
 }


### PR DESCRIPTION
Hey!

We're using absolute imports in our component library. Currently that's not supported with UXPin merge. I don't see any way to modify the underlying ts configuration.

It looks like this:

```tsx
import Component, { ThingA } from "~/components/ComponentA";
import { ThingB } from "~/components/ComponentB";
```

The `~` means the `src` folder. We could use relative import, but still no fields show up in UXPin, because in the component we also use the same absolute import.

It is set up a standard way with tsconfig paths:

```json
{
  "compilerOptions": {
    // ...
    "baseUrl": "./",
    "paths": {
      "~/*": ["./src/*"]
    }
  }
}
```

This PR is just a suggestion. I'm currently using this locally to make it work. There's a hardcoded `tsconfig.json` in it, optimally it could be configurable.

Or probably directly accepting the paths should be sufficient:

```js
{
  name: "...",
  components: {
    categories: [
      { ... },
    ],
    wrapper: "UXPinWrapper.tsx",
    webpackConfig: "uxpin.webpack.config.js",
    paths: {
      "~/*": ["./src/*"],
    }
  },
```

Also I'm already passing in the webpack config that has the exact same config. Maybe it's easier to read it form there.
Any other solution or workaround  would be appreciated.
Thanks!

