### PR TITLE
Extract doc URL when `forwardRef` is used

### DIFF
--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/__tests__/serializeJSComponent-Annotations.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/__tests__/serializeJSComponent-Annotations.test.ts
@@ -229,6 +229,19 @@ describe('SerializeJSComponent - with annotations', () => {
     });
   });
 
+  describe('named export with componentDocUrl declaration and forwardRef', () => {
+    let serialized: ImplSerializationResult;
+
+    beforeAll(async () => {
+      const component: ComponentImplementationInfo = getImplementation('NamedExportedComponentWithForwardRefAndDocUrl');
+      serialized = await serializeJSComponent(component);
+    });
+
+    it('returns correct url', () => {
+      expect(serialized.result.componentDocUrl).toEqual('https://app.uxpin.com/test');
+    });
+  });
+
   describe('function with componentDocUrl and wrappers declaration', () => {
     let serialized: ImplSerializationResult;
 

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent-DocUrl.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent-DocUrl.test.ts
@@ -30,5 +30,39 @@ describe('serializeTSComponent-DocUrl', () => {
       expect(metadata.warnings).toEqual([]);
       expect(metadata.result).toEqual(expectedMetadata);
     });
+
+    it('serializes FC with forwardRef() and url doc declaration', async () => {
+      // having
+      const component: ComponentImplementationInfo = getImplementation(
+        'NamedExportedComponentWithForwardRefAndDocUrlDeclaration'
+      );
+      const expectedMetadata: ComponentMetadata = {
+        componentDocUrl: 'https://app.uxpin.com/test',
+        defaultExported: false,
+        name: 'NamedExportedComponentWithForwardRefAndDocUrlDeclaration',
+        namespace: undefined,
+        properties: [
+          {
+            description: '',
+            isRequired: true,
+            name: 'size',
+            type: { name: 'string', structure: {} },
+          },
+          {
+            description: '',
+            isRequired: true,
+            name: 'imageUrl',
+            type: { name: 'string', structure: {} },
+          },
+        ],
+        wrappers: [],
+      };
+
+      // when
+      const metadata: Warned<ComponentMetadata> = await serializeTSComponent(component);
+      // then
+      expect(metadata.warnings).toEqual([]);
+      expect(metadata.result).toEqual(expectedMetadata);
+    });
   });
 });

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent-DocUrl.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent-DocUrl.test.ts
@@ -31,7 +31,7 @@ describe('serializeTSComponent-DocUrl', () => {
       expect(metadata.result).toEqual(expectedMetadata);
     });
 
-    it('serializes FC with forwardRef() and url doc declaration', async () => {
+    it('is serialized correctly with the provided url and forwardRef()', async () => {
       // having
       const component: ComponentImplementationInfo = getImplementation(
         'NamedExportedComponentWithForwardRefAndDocUrlDeclaration'

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/comments/getNodeJsDocTag.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/comments/getNodeJsDocTag.ts
@@ -9,6 +9,8 @@ export function getNodeJsDocTag(node: ts.Node, tag: CommentTags): ts.JSDocTag | 
   return comments.find((comment) => comment.getText().trim().includes(tag));
 }
 
+// When the component is wrapped inside a `React.forwardRef()` call,
+// we need to lookup the parent Node to access the JSDoc comments
 function getNodeWithJsDoc(node: ts.Node) {
   if (node.parent.kind === ts.SyntaxKind.CallExpression) {
     return node.parent;

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/comments/getNodeJsDocTag.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/comments/getNodeJsDocTag.ts
@@ -3,7 +3,7 @@ import { CommentTags } from '../../../CommentTags';
 import { getNodeJsDocTags } from './getNodeJsDocTags';
 
 export function getNodeJsDocTag(node: ts.Node, tag: CommentTags): ts.JSDocTag | undefined {
-  const nodeWithJsDoc = getNodeWithJsDoc(node)
+  const nodeWithJsDoc = getNodeWithJsDoc(node);
   const comments: ts.JSDocTag[] = getNodeJsDocTags(nodeWithJsDoc);
 
   return comments.find((comment) => comment.getText().trim().includes(tag));

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/comments/getNodeJsDocTag.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/comments/getNodeJsDocTag.ts
@@ -3,7 +3,15 @@ import { CommentTags } from '../../../CommentTags';
 import { getNodeJsDocTags } from './getNodeJsDocTags';
 
 export function getNodeJsDocTag(node: ts.Node, tag: CommentTags): ts.JSDocTag | undefined {
-  const comments: ts.JSDocTag[] = getNodeJsDocTags(node);
+  const nodeWithJsDoc = getNodeWithJsDoc(node)
+  const comments: ts.JSDocTag[] = getNodeJsDocTags(nodeWithJsDoc);
 
   return comments.find((comment) => comment.getText().trim().includes(tag));
+}
+
+function getNodeWithJsDoc(node: ts.Node) {
+  if (node.parent.kind === ts.SyntaxKind.CallExpression) {
+    return node.parent;
+  }
+  return node;
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/findExportedFunctionWithReactForwardRef.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/findExportedFunctionWithReactForwardRef.ts
@@ -42,8 +42,7 @@ function getComponentDeclaration(sourceFile: ts.SourceFile, functionName: string
     }
 
     if (ts.isArrowFunction(argument) || ts.isFunctionExpression(argument)) {
-      // return { declaration: argument, isExported: isExported(variable) };
-      return { declaration: variable.declarationList.declarations[0], isExported: isExported(variable) };
+      return { declaration: argument, isExported: isExported(variable) };
     }
   }
 

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/findExportedFunctionWithReactForwardRef.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/findExportedFunctionWithReactForwardRef.ts
@@ -42,7 +42,8 @@ function getComponentDeclaration(sourceFile: ts.SourceFile, functionName: string
     }
 
     if (ts.isArrowFunction(argument) || ts.isFunctionExpression(argument)) {
-      return { declaration: argument, isExported: isExported(variable) };
+      // return { declaration: argument, isExported: isExported(variable) };
+      return { declaration: variable.declarationList.declarations[0], isExported: isExported(variable) };
     }
   }
 

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/getComponentDocUrl.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/component/getComponentDocUrl.ts
@@ -1,8 +1,7 @@
 import * as ts from 'typescript';
 import { getUXpinDocUrlComment } from '../comments/getUXpinDocUrlComment';
-import { ComponentDeclaration } from './getPropsTypeAndDefaultProps';
 
-export function getComponentDocUrl(component: ComponentDeclaration): string | undefined {
+export function getComponentDocUrl(component: ts.Node): string | undefined {
   const componentDocUrl: ts.JSDocTag | undefined = getUXpinDocUrlComment(component);
 
   return componentDocUrl?.comment;

--- a/packages/uxpin-merge-cli/test/resources/components/javascript/NamedExportedComponentWithForwardRefAndDocUrl.jsx
+++ b/packages/uxpin-merge-cli/test/resources/components/javascript/NamedExportedComponentWithForwardRefAndDocUrl.jsx
@@ -1,0 +1,19 @@
+import React, { PropTypes } from 'react';
+
+/**
+ * @uxpinnamespace Multi.Level.CustomNamespace
+ * @uxpindocurl https://app.uxpin.com/test
+ */
+export const NamedExportedComponentWithForwardRefAndDocUrl = React.forwardRef((props) => {
+  const { imageUrl, size } = props;
+  return (
+    <div className={size}>
+      <img src={imageUrl} alt="Avatar" />
+    </div>
+  );
+});
+
+NamedExportedComponentWithForwardRefAndDocUrl.propTypes = {
+  size: PropTypes.string,
+  imageUrl: PropTypes.string,
+};

--- a/packages/uxpin-merge-cli/test/resources/components/typescript/NamedExportedComponentWithForwardRefAndDocUrlDeclaration.tsx
+++ b/packages/uxpin-merge-cli/test/resources/components/typescript/NamedExportedComponentWithForwardRefAndDocUrlDeclaration.tsx
@@ -1,0 +1,18 @@
+import React, { forwardRef } from 'react';
+
+export interface Props {
+  size: string;
+  imageUrl: string;
+}
+
+/**
+ * @uxpindocurl https://app.uxpin.com/test
+ */
+export const NamedExportedComponentWithForwardRefAndDocUrlDeclaration = forwardRef((props: Props) => {
+  const { imageUrl, size } = props;
+  return (
+    <div className={size}>
+      <img src={imageUrl} alt="Avatar" />
+    </div>
+  );
+});


### PR DESCRIPTION
## Goal

Extract correctly the `doc URL` from the component JSDoc comments when `React.forwardRef` is used.

This feature was introduced by https://github.com/UXPin/uxpin-merge-tools/pull/297/ but it does work not if the component is wrapped by a call to `React.forwardRef()`, for TypeScript implementation.

Example:

```tsx
/**
 * @uxpindocurl https://app.uxpin.com/test
 */
export const NamedExportedComponentWithForwardRefAndDocUrlDeclaration = forwardRef((props: Props) => {
  const { imageUrl, size } = props;
  return (
    <div className={size}>
      <img src={imageUrl} alt="Avatar" />
    </div>
  );
});
```

It seems OK with the JavaScript version of this pattern, but I added a test... just in case 😃 

## How to check

Tests should pass!

```
npx jest packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent-DocUrl.test.ts
```

![image](https://user-images.githubusercontent.com/5546996/204956814-96042167-672a-428b-800c-ca8800e50cd0.png)
