### PR TITLE
Extract `usePortal` property from JSdoc comments

### DIFF
--- a/packages/uxpin-merge-cli/src/common/types/ComponentRevision.ts
+++ b/packages/uxpin-merge-cli/src/common/types/ComponentRevision.ts
@@ -7,4 +7,4 @@ export interface ComponentRevision extends ComponentDefinitionPersistedPart {
 
 export type ComponentDefinitionPersistedPart = Pick<ComponentDefinition, ComponentPersistedProps>;
 
-type ComponentPersistedProps = 'name' | 'info' | 'properties' | 'namespace' | 'wrappers';
+type ComponentPersistedProps = 'name' | 'info' | 'properties' | 'namespace' | 'wrappers' | 'usePortal';

--- a/packages/uxpin-merge-cli/src/steps/experimentation/server/common/page/data/codeSync/component/getComponentsCollection.ts
+++ b/packages/uxpin-merge-cli/src/steps/experimentation/server/common/page/data/codeSync/component/getComponentsCollection.ts
@@ -17,6 +17,7 @@ export function getComponentsCollection({ revisionId, metadata }: ComponentsColl
       namespace: component.namespace,
       properties: component.properties,
       revisionId,
+      usePortal: component.usePortal,
       wrappers: component.wrappers,
     };
     return all;

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/CommentTags.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/CommentTags.ts
@@ -3,4 +3,5 @@ export enum CommentTags {
   UXPIN_NAMESPACE = '@uxpinnamespace',
   UXPIN_WRAPPERS = '@uxpinwrappers',
   UXPIN_DOC_URL = '@uxpindocurl',
+  UXPIN_USE_PORTAL = '@uxpinuseportal',
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/ComponentDefinition.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/ComponentDefinition.ts
@@ -11,6 +11,7 @@ export interface ComponentMetadata {
   properties: ComponentPropertyDefinition[];
   wrappers?: ComponentWrapper[];
   defaultExported: boolean;
+  usePortal?: boolean;
 }
 
 export interface ComponentDefinition extends ComponentMetadata {

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/__tests__/serializeJSComponent.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/__tests__/serializeJSComponent.test.ts
@@ -576,5 +576,31 @@ ReferenceError: some is not defined
         expect(serializedProps.warnings).toEqual([]);
       });
     });
+
+    it('serializes component with `usePortal` attribute', () => {
+      // given
+      const component: ComponentImplementationInfo = getImplementation('FunctionWithUsePortalDeclaration');
+      const expectedMetadata: ComponentMetadata = {
+        defaultExported: true,
+        usePortal: true,
+        name: 'FunctionWithUsePortalDeclaration',
+        properties: [
+          {
+            description: '',
+            isRequired: true,
+            name: 'name',
+            type: { name: 'string', structure: {} },
+          },
+        ],
+        wrappers: [],
+      };
+
+      // when
+      return serializeJSComponent(component).then((serializedProps) => {
+        // then
+        expect(serializedProps.result).toEqual(expectedMetadata);
+        expect(serializedProps.warnings).toEqual([]);
+      });
+    });
   });
 });

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/serializeJSComponent.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/serializeJSComponent.ts
@@ -64,14 +64,15 @@ function getComponentWrappers(parsed: ComponentDoc, implInfo: ComponentImplement
 function getValuesFromComments(
   name: string,
   parsed: ComponentDoc
-): Pick<PartialResult, 'namespace' | 'componentDocUrl'> {
+): Pick<PartialResult, 'namespace' | 'componentDocUrl' | 'usePortal'> {
   const jsDocTags: string[] = getJSDocTagsArrayFromString(parsed.description);
   const namespaceTag: string = getCommentTag(CommentTags.UXPIN_NAMESPACE, jsDocTags) || '';
   const componentDocUrlTag: string = getCommentTag(CommentTags.UXPIN_DOC_URL, jsDocTags) || '';
 
   const namespace: ComponentNamespace | undefined = getComponentNamespaceFromDescription(name, namespaceTag);
   const componentDocUrl: string | undefined = getComponentDocUrlFromDescription(componentDocUrlTag);
-  return { namespace, componentDocUrl };
+  const usePortal: boolean | undefined = !!getCommentTag(CommentTags.UXPIN_USE_PORTAL, jsDocTags) || undefined;
+  return { namespace, componentDocUrl, usePortal };
 }
 
 function thunkGetSummaryResult(path: string): (propResults: PartialResult) => ImplSerializationResult {
@@ -92,4 +93,5 @@ interface PartialResult {
   properties: PropDefinitionSerializationResult[];
   wrappers: Warned<ComponentWrapper[]>;
   defaultExported: boolean;
+  usePortal?: boolean;
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent-usePortal.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent-usePortal.test.ts
@@ -1,0 +1,32 @@
+import { Warned } from '../../../../../../common/warning/Warned';
+import { ComponentImplementationInfo } from '../../../../../discovery/component/ComponentInfo';
+import { ComponentMetadata } from '../../../ComponentDefinition';
+import { serializeTSComponent } from '../serializeTSComponent';
+import { getImplementation } from './serializeTSComponent.test';
+
+describe('serializeTSComponent-usePortal', () => {
+  it('is serialized with `usePortal` property', async () => {
+    // having
+    const component: ComponentImplementationInfo = getImplementation('FunctionWithUsePortalDeclaration');
+    const expectedMetadata: ComponentMetadata = {
+      defaultExported: true,
+      usePortal: true,
+      name: 'FunctionWithUsePortalDeclaration',
+      properties: [
+        {
+          description: '',
+          isRequired: true,
+          name: 'name',
+          type: { name: 'string', structure: {} },
+        },
+      ],
+      wrappers: [],
+    };
+
+    // when
+    const metadata: Warned<ComponentMetadata> = await serializeTSComponent(component);
+    // then
+    expect(metadata.warnings).toEqual([]);
+    expect(metadata.result).toEqual(expectedMetadata);
+  });
+});

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/comments/jsdoc-useportal.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/comments/jsdoc-useportal.ts
@@ -1,0 +1,8 @@
+import { CommentTags } from '../../../CommentTags';
+import { ComponentDeclaration } from '../component/getPropsTypeAndDefaultProps';
+import { getNodeJsDocTag } from './jsdoc-helpers';
+
+export function getComponentUsePortal(declaration: ComponentDeclaration) {
+  const node = getNodeJsDocTag(declaration, CommentTags.UXPIN_USE_PORTAL);
+  return Boolean(node);
+}

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/serializeTSComponent.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/serializeTSComponent.ts
@@ -11,6 +11,7 @@ import { PropDefinitionSerializationResult } from '../PropDefinitionSerializatio
 import { getComponentDeclaration } from './component/getComponentDeclaration';
 import { getComponentDocUrl } from './comments/jsdoc-docurl';
 import { getComponentNamespace } from './comments/jsdoc-namespace';
+import { getComponentUsePortal } from './comments/jsdoc-useportal';
 import { getComponentName } from './component/getComponentName';
 import { getComponentWrappers } from './component/getComponentWrappers';
 import { ComponentDeclaration } from './component/getPropsTypeAndDefaultProps';
@@ -34,6 +35,7 @@ export async function serializeTSComponent(component: ComponentImplementationInf
   const wrappers: ComponentWrapper[] = getComponentWrappers(declaration);
   const validatedWrappers: Warned<ComponentWrapper[]> = validateWrappers(wrappers, component);
   const defaultExported: boolean = isDefaultExported(declaration, context);
+  const usePortal: boolean | undefined = getComponentUsePortal(declaration) || undefined;
 
   return {
     result: {
@@ -43,6 +45,7 @@ export async function serializeTSComponent(component: ComponentImplementationInf
       namespace,
       properties: validatedProps.map(({ result }) => result),
       wrappers: validatedWrappers.result,
+      usePortal,
     },
     warnings: joinWarningLists(
       [...validatedProps.map(({ warnings }) => warnings), validatedWrappers.warnings],

--- a/packages/uxpin-merge-cli/test/resources/components/javascript/FunctionWithUsePortalDeclaration.jsx
+++ b/packages/uxpin-merge-cli/test/resources/components/javascript/FunctionWithUsePortalDeclaration.jsx
@@ -1,0 +1,19 @@
+import React, { PropTypes } from 'react';
+
+/**
+ * Some component description
+ *
+ * @uxpinuseportal
+ * @param props { name: string }
+ */
+export default function FunctionWithUsePortalDeclaration({ name }) {
+  return (
+    <div>
+      <label className={name}>{name}</label>
+    </div>
+  );
+}
+
+FunctionWithUsePortalDeclaration.propTypes = {
+  name: PropTypes.string.isRequired,
+};

--- a/packages/uxpin-merge-cli/test/resources/components/typescript/FunctionWithUsePortalDeclaration.tsx
+++ b/packages/uxpin-merge-cli/test/resources/components/typescript/FunctionWithUsePortalDeclaration.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+export interface Props {
+  name: string;
+}
+
+/**
+ * @uxpinuseportal
+ */
+export default function FunctionWithUsePortalDeclaration({ name }: Props): JSX.Element {
+  return (
+    <div>
+      <label className={name}>{name}</label>
+    </div>
+  );
+}


### PR DESCRIPTION
## Goal

Add a new boolean property `usePortal` to component data, extracted from the JSDoc section at the top of the document.

```js
/**
 * @uxpinuseportal
 */
```

This property will be used to render components inside a `React.Portal`, instead of the usual canvas, which is useful for components that need to be positioned absolutely on the screen: modals, toast (notifications)...

## How test

- Open one of the Merge templates
- Link the Merge CLI
- Add `@uxpinuseportal` in the JSdoc comments at the top of the component (example below)
- Run the dump command
- Check that `usePortal: true` property is added to the component