### PR TITLE
Allow absolute imports by handling TS path mapping

### DIFF
--- a/packages/uxpin-merge-cli/CHANGELOG.md
+++ b/packages/uxpin-merge-cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.10.0] - 2022-12-19
+
+### Added
+
+- Allow absolute imports by handling TypeScript path mapping ([#355](https://github.com/UXPin/uxpin-merge-tools/pull/355))
+
 ## [2.9.0] - 2022-12-02
 
 ### Added

--- a/packages/uxpin-merge-cli/package.json
+++ b/packages/uxpin-merge-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxpin/merge-cli",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "The Command-line tool integrates the Design System repository with: https://www.uxpin.com/merge",
   "repository": {
     "type": "git",

--- a/packages/uxpin-merge-cli/src/steps/discovery/component/ComponentInfo.ts
+++ b/packages/uxpin-merge-cli/src/steps/discovery/component/ComponentInfo.ts
@@ -1,3 +1,5 @@
+import * as ts from 'typescript';
+
 export interface ComponentInfo {
   dirPath: string;
   implementation: ComponentImplementationInfo;
@@ -20,4 +22,8 @@ export interface ComponentDocumenationInfo {
 
 export interface ComponentPresetInfo {
   path: string;
+}
+
+export interface TypeScriptConfig {
+  compilerOptions: ts.CompilerOptions;
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/getComponentMetadata.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/getComponentMetadata.ts
@@ -1,13 +1,16 @@
-import { ComponentImplementationInfo } from '../../../discovery/component/ComponentInfo';
+import { ComponentImplementationInfo, TypeScriptConfig } from '../../../discovery/component/ComponentInfo';
 import { thunkGetSummaryResultForInvalidComponent } from './getSummaryResultForInvalidComponent';
 import { ImplSerializationResult } from './ImplSerializationResult';
 import { serializeJSComponent } from './javascript/serializeJSComponent';
 import { serializeTSComponent } from './typescript/serializeTSComponent';
 
-export function getComponentMetadata(component: ComponentImplementationInfo): Promise<ImplSerializationResult> {
+export function getComponentMetadata(
+  component: ComponentImplementationInfo,
+  config?: TypeScriptConfig
+): Promise<ImplSerializationResult> {
   let promise: Promise<ImplSerializationResult>;
   if (component.lang === 'typescript') {
-    promise = serializeTSComponent(component);
+    promise = serializeTSComponent(component, config);
   } else {
     promise = serializeJSComponent(component);
   }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/context/getSerializationContext.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/context/getSerializationContext.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import { ComponentImplementationInfo } from '../../../../../discovery/component/ComponentInfo';
+import { ComponentImplementationInfo, TypeScriptConfig } from '../../../../../discovery/component/ComponentInfo';
 import { findComponentFile } from '../component/findComponentFile';
 
 export interface TSSerializationContext {
@@ -9,12 +9,19 @@ export interface TSSerializationContext {
   program: ts.Program;
 }
 
-export function getSerializationContext(component: ComponentImplementationInfo): TSSerializationContext {
+export function getSerializationContext(
+  component: ComponentImplementationInfo,
+  config?: TypeScriptConfig
+): TSSerializationContext {
   const { path } = component;
+
   const program: ts.Program = ts.createProgram([path], {
     jsx: ts.JsxEmit.React,
     module: ts.ModuleKind.CommonJS,
     target: ts.ScriptTarget.ES2015,
+    // we can't just use `...config?.compilerOptions`
+    baseUrl: config?.compilerOptions?.baseUrl,
+    paths: config?.compilerOptions?.paths,
   });
 
   const file: ts.SourceFile | undefined = findComponentFile(program, path);

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/serializeTSComponent.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/serializeTSComponent.ts
@@ -1,6 +1,6 @@
 import { joinWarningLists } from '../../../../../common/warning/joinWarningLists';
 import { Warned } from '../../../../../common/warning/Warned';
-import { ComponentImplementationInfo } from '../../../../discovery/component/ComponentInfo';
+import { ComponentImplementationInfo, TypeScriptConfig } from '../../../../discovery/component/ComponentInfo';
 import { validateWrappers } from '../../../validation/validateWrappers';
 import { ComponentNamespace } from '../../ComponentDefinition';
 import { serializeAndValidateParsedProperties } from '../../props/serializeAndValidateParsedProperties';
@@ -19,8 +19,11 @@ import { isDefaultExported } from './component/isDefaultExported';
 import { getSerializationContext, TSSerializationContext } from './context/getSerializationContext';
 import { parseTSComponentProperties } from './parseTSComponentProperties';
 
-export async function serializeTSComponent(component: ComponentImplementationInfo): Promise<ImplSerializationResult> {
-  const context: TSSerializationContext = getSerializationContext(component);
+export async function serializeTSComponent(
+  component: ComponentImplementationInfo,
+  config?: TypeScriptConfig
+): Promise<ImplSerializationResult> {
+  const context: TSSerializationContext = getSerializationContext(component, config);
 
   const declaration: ComponentDeclaration | undefined = getComponentDeclaration(context);
   if (!declaration) {


### PR DESCRIPTION
## Goal

Following the discussion started with this PR https://github.com/UXPin/uxpin-merge-tools/pull/338 the goal is to allow the use of TypeScript absolute imports using [path mapping](https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping).

The strategy is to read the user's TypeScript config (`tsconfig.json` file) and apply the `baseUrl` and `paths` options to the TypeScript config used by the CLI.

Compared to #338 `tsconfig.json` is read from the file system only once, not for every component.


## How to check

To check absolute imports, I have setup a branch in the UXPin TypeScript Merge template:

https://github.com/uxpin-merge/template-merge-typescript-ds/tree/try-absolute-imports-with-ts-paths

The following properties are needed inside the `compilerOptions`

```json
  "baseUrl": "./",
  "paths": {
    "~/*": ["./src/*"]
  }
```

To reproduce @JuhG issue, I created a `Card` component, with a `Size` type used inside the props, imported using `~`:

```tsx
import { Size } from "~/types";

type Props = {
  children: React.ReactNode;
  size: Size;
};
```

Steps

- In Merge CLI, run `make build-watch` command
- In Merge TS template, run the experimental mode: `npm run uxpin`
- Check the `Card` component in UXPin editor

### Before `2.9.0`

The `Size` property is not parsed correctly

![image](https://user-images.githubusercontent.com/5546996/208328845-c305f682-37f6-4716-a485-8488f83b442d.png)


### After `2.10.0`

`Size` property is parsed correctly!

![image](https://user-images.githubusercontent.com/5546996/208329291-170784b9-98ed-420e-9594-fff528ba9408.png)
