### PR TITLE
Add  `color` control type to render color properties in UXPin editor

### DIFF
--- a/packages/uxpin-merge-cli/CHANGELOG.md
+++ b/packages/uxpin-merge-cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.11.0] - 2022-01-16
+
+### Added
+
+- Supports color type with `@uxpincontroltype color`
+
 ## [2.10.0] - 2022-12-19
 
 ### Added

--- a/packages/uxpin-merge-cli/CHANGELOG.md
+++ b/packages/uxpin-merge-cli/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## [2.11.0] - 2022-01-16
+## [2.11.0] - 2023-01-18
 
 ### Added
 
-- Supports color type with `@uxpincontroltype color`
+- Supports color type with `@uxpincontroltype color` ([#361](https://github.com/UXPin/uxpin-merge-tools/pull/361))
+
+### Changed
+
+- Upgrade packages (`decode-uri-components`, `utils-loader`, `json5`, `minimist`, `follow-redirects`, `aws-sdk`, `minimatch`...) from dependabot alerts
 
 ## [2.10.0] - 2022-12-19
 

--- a/packages/uxpin-merge-cli/package.json
+++ b/packages/uxpin-merge-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxpin/merge-cli",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "The Command-line tool integrates the Design System repository with: https://www.uxpin.com/merge",
   "repository": {
     "type": "git",

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/ComponentPropertyDefinition.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/ComponentPropertyDefinition.ts
@@ -114,6 +114,7 @@ export interface CustomControlType<T extends CustomControlTypeName = CustomContr
 
 export enum CustomControlTypeName {
   CodeEditor = 'codeeditor',
+  Color = 'color',
   Input = 'input',
   Interactions = 'interactions',
   Number = 'number',
@@ -124,6 +125,7 @@ export enum CustomControlTypeName {
 
 export interface CustomControlTypeStructureMap {
   [CustomControlTypeName.CodeEditor]: {};
+  [CustomControlTypeName.Color]: {};
   [CustomControlTypeName.Input]: {};
   [CustomControlTypeName.Interactions]: {};
   [CustomControlTypeName.Number]: {};

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/__tests__/serializeJSComponent-CustomMetadata.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/__tests__/serializeJSComponent-CustomMetadata.test.ts
@@ -233,6 +233,19 @@ component.`,
               structure: {},
             },
           },
+          {
+            customType: {
+              name: CustomControlTypeName.Color,
+              structure: {},
+            },
+            description: '',
+            isRequired: false,
+            name: 'backgroundColor',
+            type: {
+              name: 'string',
+              structure: {},
+            },
+          },
         ],
         wrappers: [],
       };

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/props/parsing/descriptors/parseTypeTag.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/props/parsing/descriptors/parseTypeTag.ts
@@ -15,6 +15,7 @@ export function parseTypeTag(value: string): ParseResult {
 
   switch (typeMatch[0]) {
     case CustomControlTypeName.CodeEditor:
+    case CustomControlTypeName.Color:
     case CustomControlTypeName.Input:
     case CustomControlTypeName.Interactions:
     case CustomControlTypeName.Number:

--- a/packages/uxpin-merge-cli/src/steps/serialization/validation/props/isCustomTypeAllowedForType.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/validation/props/isCustomTypeAllowedForType.ts
@@ -16,6 +16,7 @@ const CUSTOM_TYPE_ALLOWANCE_MAP: {
   [key in CustomControlTypeName]?: PropertyTypeName[];
 } = {
   [CustomControlTypeName.CodeEditor]: [...ARRAY_TYPES, ...ELEMENT_TYPES, ...OBJECT_TYPES, 'any', 'func', 'string'],
+  [CustomControlTypeName.Color]: ['string'],
   [CustomControlTypeName.Input]: TEXT_EDITABLE_TYPES,
   [CustomControlTypeName.Interactions]: ['func'],
   [CustomControlTypeName.Number]: ['number'],

--- a/packages/uxpin-merge-cli/test/resources/components/javascript/PropTypesWithTextfieldCustomType.jsx
+++ b/packages/uxpin-merge-cli/test/resources/components/javascript/PropTypesWithTextfieldCustomType.jsx
@@ -46,6 +46,10 @@ PropTypesWithTextfieldCustomType.propTypes = {
    * @uxpincontroltype textfield(10)
    */
   childrenProp2: PropTypes.node,
+  /**
+   * @uxpincontroltype color
+   */
+  backgroundColor: PropTypes.string,
 };
 
 export default PropTypesWithTextfieldCustomType;


### PR DESCRIPTION
## Goal

This PR adds support for a new `@uxpincontroltype` value: `color`

Users would have to explictly use the following JSDoc comment in their code, to get a color picker in property panel of the Merge editor.

```js
/**
 * @uxpincontroltype color
 */
backgroundColor: PropTypes.string,
```

## Context

In the UXPin editor, a color picker should be displayed for properties that have been identified as colors: see https://github.com/UXPin/uxpin-issues/issues/1266 for the details

![image](https://user-images.githubusercontent.com/5546996/212579338-8b1deaa5-d6eb-4ddb-be7e-bb87568ff1b1.png)

The existing control types are documented here:

https://www.uxpin.com/docs/merge/configuring-the-properties-panel/#control-types

## How to check

- Install `@uxpin/merge-cli@2.11.0-dev.108`
- Add the JSDoc before an existing property (see the example above)
- Launch the dump command: `npx uxpin-merge dump`
- The output should include something like this:

```json
{
  "customType": {
    "name": "color",
    "structure": {}
  },
  "description": "",
  "isRequired": true,
  "name": "myColor",
  "type": {
    "name": "string",
    "structure": {}
  }
}
```



