### PR TITLE
Add header to OPTIONS requests

### DIFF
--- a/packages/uxpin-merge-cli/CHANGELOG.md
+++ b/packages/uxpin-merge-cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.0.1] - 2023-02-15
+
+### Fixed
+
+- Adds header in experimental mode to fix CORS error in Chrome ([#369](https://github.com/UXPin/uxpin-merge-tools/pull/369))
+
 ## [3.0.0] - 2023-02-03
 
 ### Breaking changes

--- a/packages/uxpin-merge-cli/package.json
+++ b/packages/uxpin-merge-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxpin/merge-cli",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "The Command-line tool integrates the Design System repository with: https://www.uxpin.com/merge",
   "repository": {
     "type": "git",

--- a/packages/uxpin-merge-cli/src/steps/experimentation/server/headers/getAccessControlHeaders.ts
+++ b/packages/uxpin-merge-cli/src/steps/experimentation/server/headers/getAccessControlHeaders.ts
@@ -7,6 +7,7 @@ export function getAccessControlHeaders(incomingHeaders: IncomingHttpHeaders = {
       'Access-Control-Allow-Credentials': 'true',
       'Access-Control-Allow-Headers': 'Origin, X-Requested-With, Content-Type, Accept, Range',
       'Access-Control-Allow-Method': 'GET, OPTIONS, POST, PUT',
+      'Access-Control-Allow-Private-Network': 'true',
     },
     incomingHeaders
   );


### PR DESCRIPTION
Add following header to make the Expermental Mode works with Chrome 104 (https://developer.chrome.com/blog/private-network-access-preflight/):

- 'Access-Control-Allow-Private-Network': 'true'

close https://github.com/UXPin/uxpin-issues/issues/1353