### PR TITLE
Handle more than one property symbol and connect types into union typ…

### DIFF
--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/parseTSComponentProperties.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/parseTSComponentProperties.ts
@@ -16,13 +16,11 @@ export function parseTSComponentProperties(
   componentDeclaration: ComponentDeclaration
 ): PropDefinitionParsingResult[] {
   const { propsTypeNode, defaultProps } = getPropsTypeAndDefaultProps(context, componentDeclaration);
-
   if (!propsTypeNode) {
     throw new Error('No component properties found');
   }
 
   const typeFromTypeNode: ts.Type = context.checker.getTypeFromTypeNode(propsTypeNode);
-
   const props: TypeProps = getPropertiesFromType(typeFromTypeNode);
 
   return [

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/parseTSComponentProperties.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/parseTSComponentProperties.ts
@@ -16,11 +16,13 @@ export function parseTSComponentProperties(
   componentDeclaration: ComponentDeclaration
 ): PropDefinitionParsingResult[] {
   const { propsTypeNode, defaultProps } = getPropsTypeAndDefaultProps(context, componentDeclaration);
+
   if (!propsTypeNode) {
     throw new Error('No component properties found');
   }
 
   const typeFromTypeNode: ts.Type = context.checker.getTypeFromTypeNode(propsTypeNode);
+
   const props: TypeProps = getPropertiesFromType(typeFromTypeNode);
 
   return [

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/property/symbol/getValidSymbol.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/property/symbol/getValidSymbol.ts
@@ -1,16 +1,17 @@
-import { head } from 'lodash';
 import * as ts from 'typescript';
+import { createUnionTypeNode } from 'typescript';
 
-export function getValidSymbol(symbol: ts.Symbol): ts.Symbol | undefined {
+export function getValidSymbols(symbol: ts.Symbol): ts.Symbol[] {
   if (symbol.valueDeclaration) {
-    return symbol;
+    return [symbol];
   }
 
   if (symbol.declarations?.length && symbol.declarations.length > 0) {
-    const declaration: DeclarationWithSymbol | undefined = getFirstDeclarationWithSymbol(symbol.declarations);
-
-    return declaration ? declaration.symbol : undefined;
+    const declarations: DeclarationWithSymbol[] = getDeclarationsWithSymbol(symbol.declarations);
+    return declarations.map((declaration) => declaration.symbol);
   }
+
+  return [];
 }
 
 interface DeclarationWithSymbol extends ts.Declaration {
@@ -21,6 +22,6 @@ function hasSymbol(declaration: ts.Declaration): declaration is DeclarationWithS
   return declaration.hasOwnProperty('symbol');
 }
 
-function getFirstDeclarationWithSymbol(declarations: ts.Declaration[]): DeclarationWithSymbol | undefined {
-  return head(declarations.filter(hasSymbol));
+function getDeclarationsWithSymbol(declarations: ts.Declaration[]): DeclarationWithSymbol[] {
+  return declarations.filter(hasSymbol);
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/property/symbol/getValidSymbol.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/property/symbol/getValidSymbol.ts
@@ -1,5 +1,4 @@
 import * as ts from 'typescript';
-import { createUnionTypeNode } from 'typescript';
 
 export function getValidSymbols(symbol: ts.Symbol): ts.Symbol[] {
   if (symbol.valueDeclaration) {

--- a/packages/uxpin-merge-cli/test/integration/dump/__snapshots__/with-ts4-dump.test.ts.snap
+++ b/packages/uxpin-merge-cli/test/integration/dump/__snapshots__/with-ts4-dump.test.ts.snap
@@ -83,6 +83,48 @@ exports[`The dump command run for the with-ts4 repository prints components with
               "structure": {},
             },
           },
+          {
+            "description": "",
+            "isRequired": true,
+            "name": "icon",
+            "type": {
+              "name": "union",
+              "structure": {
+                "elements": [
+                  {
+                    "name": "literal",
+                    "structure": {
+                      "value": "icon",
+                    },
+                  },
+                  {
+                    "name": "literal",
+                    "structure": {
+                      "value": "number",
+                    },
+                  },
+                  {
+                    "name": "literal",
+                    "structure": {
+                      "value": "disc",
+                    },
+                  },
+                  {
+                    "name": "literal",
+                    "structure": {
+                      "value": "circle",
+                    },
+                  },
+                  {
+                    "name": "literal",
+                    "structure": {
+                      "value": "square",
+                    },
+                  },
+                ],
+              },
+            },
+          },
         ],
         "wrappers": [],
       },

--- a/packages/uxpin-merge-cli/test/resources/designSystems/withTS4/src/components/Avatar/Avatar.tsx
+++ b/packages/uxpin-merge-cli/test/resources/designSystems/withTS4/src/components/Avatar/Avatar.tsx
@@ -9,14 +9,24 @@ interface User {
 
 type UserWithoutEmail = Omit<User, 'email'>;
 
-export interface Props {
+type CommonProps = {
   size: string;
   imageUrl: string;
   test: Test;
   user: UserWithoutEmail;
-}
+};
 
-export default class Avatar extends React.PureComponent<Props> {
+type IconProps = CommonProps & {
+  icon: 'icon';
+};
+
+type Props = CommonProps & {
+  icon?: 'disc' | 'circle' | 'square' | 'number';
+};
+
+type AvatarProps = IconProps | Props;
+
+export default class Avatar extends React.PureComponent<AvatarProps> {
   public static displayName = 'Gravatar';
 
   public static defaultProps: Partial<Props> = {


### PR DESCRIPTION
It resolves issue for this kind of type:
```
 type CommonProps ={
     abc: string;
 }

 type IconProps = CommonProps & {
     value: "icon";
 };

 type OtherProps = CommonProps & {
     value ?: "disc" | "circle" | "square" | "number";
  };

 type Props = IconProps | OtherProps;
```

At this moment `merge-cli` returns only 'icon' as a valid value for `value` property. It happens because  this line 
https://github.com/UXPin/uxpin-merge-tools/pull/377/files#diff-1b28cb13a2f9e0c818f3837848c257d59301f51c31cc9960b34a016bec6914a2L10
To get the type of property we only consider only first valid symbol but in this case, typescript parses return two symbols.

This fix introduces handling more than one symbol for a given property. I realize this is not a perfect solution but I think it should cover the most popular cases.

My solution creates a union type when 
 1. One type is a union
 2. All of the types in every symbol have the same type but are different than `any` or `unsupported`
otherwise, it handles the first symbol as we did before fix
 

