### PR TITLE
Remove encoding of branch name during push or delete action

### DIFF
--- a/packages/uxpin-merge-cli/CHANGELOG.md
+++ b/packages/uxpin-merge-cli/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## [3.0.5] - 2023-06-26
+
+### Changed
+- Remove encoding of branch name when using push or delete commands ([#387](https://github.com/UXPin/uxpin-merge-tools/pull/387))
+
 ## [3.0.4] - 2023-06-19
 
 ### Changed

--- a/packages/uxpin-merge-cli/package.json
+++ b/packages/uxpin-merge-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxpin/merge-cli",
-  "version": "3.0.4",
+  "version": "3.0.5-dev",
   "description": "The Command-line tool integrates the Design System repository with: https://www.uxpin.com/merge",
   "repository": {
     "type": "git",

--- a/packages/uxpin-merge-cli/package.json
+++ b/packages/uxpin-merge-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxpin/merge-cli",
-  "version": "3.0.5-dev",
+  "version": "3.0.5",
   "description": "The Command-line tool integrates the Design System repository with: https://www.uxpin.com/merge",
   "repository": {
     "type": "git",

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/DeleteRepositoryPointerToBranch.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/DeleteRepositoryPointerToBranch.ts
@@ -3,7 +3,6 @@ import { isTestEnv } from '../../../program/env/isTestEnv';
 import { axiosWithEnhancedError } from '../../../utils/axiosWithEnhancedError';
 import { getAuthHeaders } from './headers/getAuthHeaders';
 import { getUserAgentHeaders } from './headers/getUserAgentHeaders';
-import { encodeBranchName } from './params/encodeBranchName';
 
 export async function deleteRepositoryPointerToBranch(opts: {
   apiDomain: string;
@@ -15,7 +14,7 @@ export async function deleteRepositoryPointerToBranch(opts: {
     return Promise.resolve();
   }
 
-  const branchName: string = encodeBranchName(opts.branch);
+  const branchName: string = opts.branch;
 
   await axiosWithEnhancedError({
     data: {

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/updateRepositoryPointerToBranch.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/updateRepositoryPointerToBranch.ts
@@ -2,7 +2,6 @@ import { isTestEnv } from '../../../program/env/isTestEnv';
 import { axiosWithEnhancedError } from '../../../utils/axiosWithEnhancedError';
 import { getAuthHeaders } from './headers/getAuthHeaders';
 import { getUserAgentHeaders } from './headers/getUserAgentHeaders';
-import { encodeBranchName } from './params/encodeBranchName';
 
 export const enum RepositoryPointerType {
   Branch = 'branch',
@@ -36,7 +35,7 @@ export async function updateRepositoryPointerToBranch(opts: {
     throw new Error('Missing auth token for repository pointer update');
   }
 
-  const branchName: string = encodeBranchName(opts.branch);
+  const branchName: string = opts.branch;
 
   return axiosWithEnhancedError({
     data: {


### PR DESCRIPTION
Fix for https://github.com/UXPin/uxpin-merge-tools/issues/388

## Overview
Remove un-necessary encoding of the branch name when using the `push` or `delete-version` commands.

## How to test locally
1. Checkout to this branch in `uxpin-merge-cli`
2. run `Make build`
3. `yarn link` in `uxpin-merge-cli`
4. `yarn link @uxpin/merge-cli` in a DS of your choice. For example we can use [MUI-Merge](https://github.com/uxpin-merge/MUI-Merge)
5. Create a new git library in UXPin and use the provided TOKEN.

### scenarios to test
* **Before fix** - push a branch with a forward slash and other variations i.e `test/test`
     * Apply the fix and try to push to the same branch and delete it to make sure no issues.

We want to make sure there will be no issues for other users that have branches before the fix.