### PR TITLE
Add a debug mode for troubleshooting

### DIFF
--- a/packages/uxpin-merge-cli/CHANGELOG.md
+++ b/packages/uxpin-merge-cli/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
+
+## [3.0.6] - 2023-07-05
+
+- Add debug mode using `DEBUG=uxpin*` ([#387](https://github.com/UXPin/uxpin-merge-tools/pull/389))
+
 ## [3.0.5] - 2023-06-26
 
 ### Changed
+
 - Remove encoding of branch name when using push or delete commands ([#387](https://github.com/UXPin/uxpin-merge-tools/pull/387))
 
 ## [3.0.4] - 2023-06-19
@@ -69,22 +75,27 @@
 ## [2.8.1] - 2022-10-18
 
 ### Changed
-- Support for normalize paths for windows  ([#328](https://github.com/UXPin/uxpin-merge-tools/pull/328))
+
+- Support for normalize paths for windows ([#328](https://github.com/UXPin/uxpin-merge-tools/pull/328))
+
 ## [2.8.0] - 2022-06-09
 
 ### Changed
+
 - `delete-version` command with `--tag` and `--branch` options ([#314](https://github.com/UXPin/uxpin-merge-tools/pull/314))
--  GitHub action to publish to packages to both npmjs and github registry ([#308](https://github.com/UXPin/uxpin-merge-tools/pull/308))
+- GitHub action to publish to packages to both npmjs and github registry ([#308](https://github.com/UXPin/uxpin-merge-tools/pull/308))
 
 ## [2.7.10] - 2021-11-17
 
 ### Changed
+
 - Better error message for unknown revision ([#299](https://github.com/UXPin/uxpin-merge-tools/pull/299))
 - added regex to account for # in tag comment ([#301](https://github.com/UXPin/uxpin-merge-tools/pull/301))
 
 ## [2.7.9] - 2021-10-25
 
 ### Changed
+
 - Added `@uxpindocurl` jsdoc support ([#297](https://github.com/UXPin/uxpin-merge-tools/pull/297))
 - Allow pushing a branch without making changes from original branch ([#294](https://github.com/UXPin/uxpin-merge-tools/pull/294))
 - Allow pushing a branch made from specific sha ([#298](https://github.com/UXPin/uxpin-merge-tools/pull/298))
@@ -93,43 +104,52 @@
 ## [2.7.8] - 2021-08-10
 
 ### Changed
+
 - Support creating tag with `--tag` option for Merge library version control ([#282](https://github.com/UXPin/uxpin-merge-tools/pull/282))
 - Support `@uxpinsort` JSDoc comment to sort union type in TS ([#285](https://github.com/UXPin/uxpin-merge-tools/pull/285))
 
 ## [2.7.7] - 2021-06-03
 
 ### Changed
+
 - Blacklist type defined under React namespace in DefinitelyTyped ([#272](https://github.com/UXPin/uxpin-merge-tools/pull/272))
 - Upgrade packages(browserslist and dns-packet) from dependabot alerts
 
 ## [2.7.6] - 2021-05-17
 
 ### Added
+
 - Blacklist some generic props such as HTMLAttributes in TS ([#271](https://github.com/UXPin/uxpin-merge-tools/pull/271))
 
 ### Changed
+
 - Replaced `http-server` with `http` for server command ([#268](https://github.com/UXPin/uxpin-merge-tools/pull/268))
 - Improved getting Component name from file path ([#269](https://github.com/UXPin/uxpin-merge-tools/pull/269))
 - Improved detecting component with forwardRef in TS ([#271](https://github.com/UXPin/uxpin-merge-tools/pull/271))
 
 ## [2.7.5] - 2021-04-14
+
 ### Added
+
 - Improved Typescript Support
   - Support React.forwardRef and React.FC ([#253](https://github.com/UXPin/uxpin-merge-tools/pull/253))
 - Support for named exported component ([#246](https://github.com/UXPin/uxpin-merge-tools/pull/246))
 
 ### Changed
+
 - Upgrade some packages(y18n, yargs-parser and elliptic) with security vulnerability
 
 ## [2.7.4] - 2021-03-31
 
 ### Added
+
 - Improved TypeScript Support:
   - Improved support for different ways of [exporting components](https://github.com/UXPin/uxpin-merge-tools/pull/248)
   - Added support for Date type
   - Added support for enum type
 
 ### Changed
+
 - TypeScript updated to v4.2.3
   - Added to allow support for the [Omit Utility Type](https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys)
   - Added to allow support for [Type-Only Imports and Exports](https://devblogs.microsoft.com/typescript/announcing-typescript-3-8/#type-only-imports-exports)
@@ -140,6 +160,7 @@
   - By default we will use react-docgen default presets
 
 ### Fixed
+
 - Fixed TypeScript serialization bug that was causing prop names inside quotes to be ignored
   - This scenario was common for customers using Stencil to generate their React Wrappers
   - Example: `"persistent": boolean;` inside a TypeScript interface was previously unrecognised
@@ -147,17 +168,20 @@
 ## [2.7.3] - 2021-03-01
 
 ### Added
+
 - Added an init command which adds the default files required by merge
 - Added a generate-presets command which reads the config file and auto generates preset files
 
 ## [2.7.2] - 2020-12-15
 
 ### Fixed
+
 - Fixed regression causing components panel to not load in Experimental Mode after 2.7.1 changes
 
 ## [2.7.1] - 2020-12-15
 
 ### Added
+
 - Added support for pushes from non-master branches:
   - New --branch option added to the CLI
   - Default branch is always master, if none is specified
@@ -165,6 +189,7 @@
   - Pushes form CI systems which work in a detached HEAD state now supported
 
 ### Changed
+
 - Improved support for TypeScript named arrow functions:
   - Derives name from component's parent's name instead of using the filename
   - See [Typescript export Problems](https://github.com/UXPin/uxpin-merge-tools/issues/208)
@@ -173,6 +198,7 @@
 - Upgraded 'typescript' version to ~3.4.0
 
 ### Fixed
+
 - Fixed bug for Windows/WSL environments affecting experimental mode:
   - WSL environment was escaping '&' characters with a '^' character
   - See [Experimental Mode not working with Windows (and WSL)](https://github.com/UXPin/uxpin-merge-tools/issues/218)
@@ -180,10 +206,12 @@
 ## [2.7.0] - 2020-10-23
 
 ### Added
+
 - Added support for named arrow functions in TypeScript:
   - See [TypeScript Arrow Function Fails to Serialize](https://github.com/UXPin/uxpin-merge-tools/issues/192)
 
 ### Changed
+
 - This release open sources the command-line tool component of the UXPin Merge technology under the GPL v3 license:
   - See [announcement blog post](https://www.uxpin.com/studio/blog/weve-open-sourced-the-merge-cli/)
 - Updated Readme.md file

--- a/packages/uxpin-merge-cli/README.md
+++ b/packages/uxpin-merge-cli/README.md
@@ -55,3 +55,14 @@ will print the list of options:
     server [options]            Start local web server and display the list of design system components
     summary [options]           Show only design system summary without building it
 ```
+
+## Debug mode
+
+Set the environment variable `DEBUG=uxpin*` to get a verbose output. It can help when troubleshooting or investigating performance issues.
+It uses the NPM package [debug](https://github.com/debug-js/debug).
+
+Example:
+
+```bash
+DEBUG=uxpin* npx uxpin-merge push --token ***
+```

--- a/packages/uxpin-merge-cli/package.json
+++ b/packages/uxpin-merge-cli/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@types/babel-core": "^6.25.2",
     "@types/commander": "^2.12.2",
+    "@types/debug": "^4.1.8",
     "@types/formidable": "^1.0.31",
     "@types/fs-extra": "^5.0.4",
     "@types/jest": "29.5.1",
@@ -109,6 +110,7 @@
     "clean-stacktrace": "^1.1.0",
     "clean-stacktrace-relative-paths": "^1.0.4",
     "commander": "^2.11.0",
+    "debug": "^4.3.4",
     "form-data": "^4.0.0",
     "formidable": "^1.2.1",
     "fs-extra": "^7.0.0",
@@ -124,6 +126,7 @@
     "p-map-series": "^1.0.0",
     "p-reduce": "^1.0.0",
     "path-sort": "^0.1.0",
+    "pretty-bytes": "5.6.0",
     "react-docgen": "^4.1.0",
     "require1k": "^1.0.1",
     "sortobject": "^1.1.1",

--- a/packages/uxpin-merge-cli/package.json
+++ b/packages/uxpin-merge-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxpin/merge-cli",
-  "version": "3.0.5",
+  "version": "3.0.5-debug-mode",
   "description": "The Command-line tool integrates the Design System repository with: https://www.uxpin.com/merge",
   "repository": {
     "type": "git",

--- a/packages/uxpin-merge-cli/package.json
+++ b/packages/uxpin-merge-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxpin/merge-cli",
-  "version": "3.0.5-debug-mode",
+  "version": "3.0.6",
   "description": "The Command-line tool integrates the Design System repository with: https://www.uxpin.com/merge",
   "repository": {
     "type": "git",

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/postPushMetadata.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/postPushMetadata.ts
@@ -1,8 +1,11 @@
 import { AxiosResponse } from 'axios';
+import debug from 'debug';
 import { DSMetadata } from '../../../program/DSMeta';
 import { axiosWithEnhancedError } from '../../../utils/axiosWithEnhancedError';
 import { getAuthHeaders } from './headers/getAuthHeaders';
 import { getUserAgentHeaders } from './headers/getUserAgentHeaders';
+
+const log = debug('uxpin');
 
 export interface PushMetadataResponse {
   message: string;
@@ -13,6 +16,13 @@ export async function postPushMetadata(
   token: string,
   metadata: DSMetadata
 ): Promise<PushMetadataResponse | null> {
+  log(
+    `Push component metadata`,
+    metadata.result.name,
+    `${metadata.result.categorizedComponents.length} components: ${metadata.result.categorizedComponents.map(
+      (component) => component.name
+    )}`
+  );
   return axiosWithEnhancedError({
     data: metadata.result,
     headers: {

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/postUploadBundle.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/postUploadBundle.ts
@@ -1,9 +1,14 @@
 import { AxiosResponse } from 'axios';
+import debug from 'debug';
 import * as FormData from 'form-data';
-import { createReadStream } from 'fs';
+import prettyBytes = require('pretty-bytes');
+import { createReadStream, statSync } from 'fs';
+
 import { axiosWithEnhancedError } from '../../../utils/axiosWithEnhancedError';
 import { getAuthHeaders } from './headers/getAuthHeaders';
 import { getUserAgentHeaders } from './headers/getUserAgentHeaders';
+
+const log = debug('uxpin');
 
 export interface UploadBundleResponse {
   url: string;
@@ -16,7 +21,9 @@ export async function postUploadBundle(
   path: string
 ): Promise<UploadBundleResponse | null> {
   const formData: FormData = new FormData();
+
   formData.append('commitHash', commitHash);
+  log('Uploading', getFileSize(path), path);
   formData.append('bundle', createReadStream(path));
 
   return axiosWithEnhancedError({
@@ -30,4 +37,11 @@ export async function postUploadBundle(
     responseType: 'json',
     url: `${domain}/code/v/1.0/push/bundle`,
   }).then((response: AxiosResponse) => (response.data as UploadBundleResponse) || null);
+}
+
+function getFileSize(filepath: string) {
+  const stats = statSync(filepath);
+  const sizeInBytes = stats.size;
+  const humanReadableSize = prettyBytes(sizeInBytes);
+  return humanReadableSize;
 }

--- a/packages/uxpin-merge-cli/src/program/command/push/steps/uploadLibrary.ts
+++ b/packages/uxpin-merge-cli/src/program/command/push/steps/uploadLibrary.ts
@@ -151,7 +151,7 @@ async function updateRepositoryPointerWithPrintMessage(opts: {
     // Update the repository pointer to point to the new branch
     await updateRepositoryPointerToBranch(opts);
 
-    printLine(`🛈  Projects using this Design System have been updated to branch [${opts.branch}]`, {
+    printLine(`√ Projects using this Design System have been updated to branch [${opts.branch}]`, {
       color: PrintColor.CYAN,
     });
   } catch (error) {

--- a/packages/uxpin-merge-cli/src/program/utils/printSerializationWarnings.ts
+++ b/packages/uxpin-merge-cli/src/program/utils/printSerializationWarnings.ts
@@ -3,5 +3,7 @@ import { Warned } from '../../common/warning/Warned';
 import { DesignSystemSnapshot } from '../../steps/serialization/DesignSystemSnapshot';
 
 export function printSerializationWarnings({ warnings }: Warned<DesignSystemSnapshot>): void {
-  console.log(stringifyWarnings(warnings));
+  if (warnings.length > 0) {
+    console.log(stringifyWarnings(warnings));
+  }
 }

--- a/packages/uxpin-merge-cli/src/steps/building/buildDesignSystem.ts
+++ b/packages/uxpin-merge-cli/src/steps/building/buildDesignSystem.ts
@@ -1,10 +1,15 @@
+import debug from 'debug';
 import { ComponentDefinition } from '../serialization/component/ComponentDefinition';
 import { BuildOptions } from './BuildOptions';
 import { getCompiler } from './compiler/getCompiler';
 import { createComponentsLibrary } from './library/createComponentsLibrary';
 
+const log = debug('uxpin');
+
 export async function buildDesignSystem(components: ComponentDefinition[], options: BuildOptions): Promise<void> {
+  log(`Create component library (${components.length} components)...`);
   await createComponentsLibrary(components, options);
+  log('Bundle design system library with Webpack...');
   await bundle(options);
 }
 

--- a/packages/uxpin-merge-cli/src/steps/building/compiler/webpack/WebpackCompiler.ts
+++ b/packages/uxpin-merge-cli/src/steps/building/compiler/webpack/WebpackCompiler.ts
@@ -1,7 +1,11 @@
+import debug from 'debug';
+import prettyBytes = require('pretty-bytes');
+import * as path from 'path';
 import * as webpack from 'webpack';
 import { formatWebpackErrorMessages } from '../../../../utils/webpack/formatWebpackErrorMessages';
 import { Compiler } from '../Compiler';
 
+const log = debug('uxpin:webpack');
 export class WebpackCompiler implements Compiler {
   private compiler: webpack.Compiler;
 
@@ -10,11 +14,14 @@ export class WebpackCompiler implements Compiler {
   }
 
   public compile(): Promise<void> {
+    log(`Compile with Webpack ${webpack.version} ${logInput(this.config)}`);
     return new Promise((resolve, reject) => {
       this.compiler.run((err, stats) => {
         if (err) {
           return reject(err);
         }
+
+        if (stats) logOutput(stats);
 
         if (stats?.hasErrors()) {
           return reject(new Error(formatWebpackErrorMessages(stats)));
@@ -24,4 +31,25 @@ export class WebpackCompiler implements Compiler {
       });
     });
   }
+}
+
+function logInput(config: webpack.Configuration) {
+  const entries = config.entry;
+  if (Array.isArray(entries)) return (entries as string[]).map(getFilename).join(', ');
+  if (typeof entries === 'string') return getFilename(entries as string);
+  return '';
+}
+
+function logOutput(stats: webpack.Stats) {
+  const assets = stats.toJson().assets || [];
+  log(`Output ${assets.map(logAssetSummary).join(', ')}`);
+}
+
+function logAssetSummary(asset: { name: string; size: number }) {
+  // TODO: Webpack does not export `StatAsset` type?
+  return asset.name + ': ' + prettyBytes(asset.size);
+}
+
+function getFilename(filepath: string) {
+  return path.parse(filepath).base;
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/getComponentMetadata.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/getComponentMetadata.ts
@@ -1,8 +1,11 @@
+import debug from 'debug';
 import { ComponentImplementationInfo, TypeScriptConfig } from '../../../discovery/component/ComponentInfo';
 import { thunkGetSummaryResultForInvalidComponent } from './getSummaryResultForInvalidComponent';
 import { ImplSerializationResult } from './ImplSerializationResult';
 import { serializeJSComponent } from './javascript/serializeJSComponent';
 import { serializeTSComponent } from './typescript/serializeTSComponent';
+
+const log = debug('uxpin:serialization');
 
 export function getComponentMetadata(
   component: ComponentImplementationInfo,
@@ -10,8 +13,10 @@ export function getComponentMetadata(
 ): Promise<ImplSerializationResult> {
   let promise: Promise<ImplSerializationResult>;
   if (component.lang === 'typescript') {
+    log(`Serialize TS component`, component.path);
     promise = serializeTSComponent(component, config);
   } else {
+    log(`Serialize JS component`, component.path);
     promise = serializeJSComponent(component);
   }
   return promise.catch(thunkGetSummaryResultForInvalidComponent(component.path));

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/presets/jsx/compile/compilePresets.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/presets/jsx/compile/compilePresets.ts
@@ -1,3 +1,4 @@
+import debug from 'debug';
 import { unlink } from 'fs-extra';
 import { join, parse } from 'path';
 import * as webpack from 'webpack';
@@ -11,9 +12,14 @@ import { createBundleSource } from '../bundle/createBundleSource';
 import { generateVirtualModules, VirtualComponentModule } from './generateVirtualModules';
 import { getPresetsBundleWebpackConfig } from './getPresetsBundleWebpackConfig';
 
+const log = debug('uxpin:serialization:presets');
+
 export async function compilePresets(programArgs: ProgramArgs, components: ComponentDefinition[]): Promise<string> {
+  log('Create temporary bundle');
   const sourcePath: string = await createBundleSource(programArgs, components);
+  log(`Compile presets with Webpack (${components.length} components)`);
   const bundlePath: string = await compileWithWebpack(programArgs, components, sourcePath);
+  log('Compilation OK, delete temporary bundle');
   await unlink(sourcePath);
 
   return bundlePath;
@@ -38,6 +44,7 @@ async function compileWithWebpack(
     virtualModules,
     webpackConfig,
   });
+
   const compiler: Compiler = new WebpackCompiler(config);
   await compiler.compile();
 

--- a/packages/uxpin-merge-cli/src/steps/serialization/vcs/getVcsDetails.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/vcs/getVcsDetails.ts
@@ -1,3 +1,4 @@
+import debug from 'debug';
 import { getApiDomain } from '../../../common/services/UXPin/getApiDomain';
 import { getLatestCommitHash } from '../../../common/services/UXPin/getLatestCommitHash';
 import { BuildOptions } from '../../../steps/building/BuildOptions';
@@ -8,6 +9,8 @@ import { filterMovedFiles } from './filterMovedFiles';
 import { getRepositoryAdapter } from './repositories/getRepositoryAdapter';
 import { RepositoryAdapter, RepositoryPointer } from './repositories/RepositoryAdapter';
 import { Command } from '../../../program/command/Command';
+
+const log = debug('uxpin');
 
 export async function getVcsDetails(
   paths: ProjectPaths,
@@ -20,6 +23,7 @@ export async function getVcsDetails(
   let latestCommitHash: string | null = null;
 
   if (buildOptions.token && shouldGetLatestCommitHash) {
+    log(`Fetch latest commit hash`);
     latestCommitHash = await getLatestCommitHash(
       getApiDomain(buildOptions.uxpinApiDomain!),
       repositoryPointer.branchName,
@@ -33,6 +37,8 @@ export async function getVcsDetails(
     paths,
   };
 
+  log(`Latest commit`, vcs.branchName, vcs.commitHash);
+
   if (latestCommitHash) {
     const movedFiles: MovedFilePathsMap = await repositoryAdapter.getMovedFiles(
       latestCommitHash,
@@ -43,6 +49,7 @@ export async function getVcsDetails(
       components: filterMovedFiles(movedFiles, categorizedComponents),
       diffSourceCommitHash: latestCommitHash,
     };
+    if (Object.keys(movedFiles).length) log(`Moved files`, Object.keys(movedFiles).length);
   }
 
   return vcs;

--- a/packages/uxpin-merge-cli/src/steps/serialization/vcs/repositories/git/util/isGitRepository.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/vcs/repositories/git/util/isGitRepository.ts
@@ -1,10 +1,15 @@
+import debug from 'debug';
+
 import { execAsync } from '../../../../../../utils/child_process/execAsync';
+
+const log = debug('uxpin');
 
 export async function isGitRepository(cwd: string): Promise<boolean> {
   try {
     await execAsync('git status', { cwd });
     return true;
-  } catch (e) {
+  } catch (error) {
+    log(`git status failed`, (error as Error).message);
     return false;
   }
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/vcs/repositories/git/util/isGitRepository.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/vcs/repositories/git/util/isGitRepository.ts
@@ -6,10 +6,11 @@ const log = debug('uxpin');
 
 export async function isGitRepository(cwd: string): Promise<boolean> {
   try {
+    log('Git repository check');
     await execAsync('git status', { cwd });
     return true;
   } catch (error) {
-    log(`git status failed`, (error as Error).message);
+    log((error as Error).message);
     return false;
   }
 }

--- a/packages/uxpin-merge-cli/src/utils/axiosWithEnhancedError.ts
+++ b/packages/uxpin-merge-cli/src/utils/axiosWithEnhancedError.ts
@@ -7,7 +7,7 @@ export async function axiosWithEnhancedError(options: AxiosRequestConfig): Axios
   log((options.method || 'GET').toUpperCase(), options.url);
   try {
     const result = await axios(options);
-    log(result.status + ' ' + result.statusText)
+    log(result.status + ' ' + result.statusText);
     return result;
   } catch (error) {
     if ((error as AxiosError).response) {

--- a/packages/uxpin-merge-cli/src/utils/axiosWithEnhancedError.ts
+++ b/packages/uxpin-merge-cli/src/utils/axiosWithEnhancedError.ts
@@ -1,14 +1,22 @@
 import axios, { AxiosError, AxiosPromise, AxiosRequestConfig } from 'axios';
+import debug from 'debug';
 
-export function axiosWithEnhancedError(options: AxiosRequestConfig): AxiosPromise {
-  return axios(options).catch((error: AxiosError) => {
-    if (error.response) {
+const log = debug('uxpin:http');
+
+export async function axiosWithEnhancedError(options: AxiosRequestConfig): AxiosPromise {
+  log((options.method || 'GET').toUpperCase(), options.url);
+  try {
+    const result = await axios(options);
+    log(result.status + ' ' + result.statusText)
+    return result;
+  } catch (error) {
+    if ((error as AxiosError).response) {
       throw {
-        ...(error.response.data as any),
+        ...((error as AxiosError)?.response?.data as any),
         url: options.url,
       };
     } else {
       throw error;
     }
-  });
+  }
 }

--- a/packages/uxpin-merge-cli/yarn.lock
+++ b/packages/uxpin-merge-cli/yarn.lock
@@ -1857,6 +1857,13 @@
   dependencies:
     commander "*"
 
+"@types/debug@^4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.8.tgz#cef723a5d0a90990313faec2d1e22aee5eecb317"
+  integrity sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==
+  dependencies:
+    "@types/ms" "*"
+
 "@types/eslint-scope@^3.7.0", "@types/eslint-scope@^3.7.3":
   version "3.7.4"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.4.tgz#37fc1223f0786c39627068a12e94d6e6fc61de16"
@@ -1984,6 +1991,11 @@
   integrity sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==
   dependencies:
     "@types/unist" "*"
+
+"@types/ms@*":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
 "@types/node@*":
   version "8.0.31"
@@ -6404,6 +6416,11 @@ prettier@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+
+pretty-bytes@5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
+  integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
 
 pretty-format@^24.9.0:
   version "24.9.0"


### PR DESCRIPTION
## Goal

In order to help when troubleshooting issues in the Merge CLI, this PR introduces the "debug" mode.

What "debug" mode allows you to see:

- Every HTTP request made by the CLI, with the end-point called, the response code and the time it takes to get the response
- Every call to Webpack with the actual version, the input file (the entry) and the generated output with its size (the bundle), and the time it took
- Every serialization process for every single component

It relies on the well-known (a kind of standard in the Node.js community) `debug` package: https://github.com/debug-js/debug

You add an environment variable called `DEBUG` in the command line with the "scope" of the debug statements you want to see, so you can adjust to inspect only things you are interested in.

## How to use it

All you need is to prefix the command (push, experimental mode... anything) with a `DEBUG` environment variable.

Example:

```
DEBUG=uxpin* npx uxpin-merge push --token ***
```

All output is under the namespace `uxpin`.

Then there are sub-parts: `uxpin:http`, `uxpin:webpack`
So basically you start the command with `DEBUG=uxpin*` to get **everything** related to UXPin Merge.

if you do  `DEBUG=uxpin` you'd get only the **top level uxpin entries** (which only gives a raw overview of the process).

Don't try `DEBUG=*` because Babel also uses it and it prints a lot of things (every single statement parsed, pages and pages of code...) don't do that! 😄 

## Screenshot

![image](https://github.com/UXPin/uxpin-merge-tools/assets/5546996/5bb79084-34eb-4c34-b0bc-03632c5ce2d2)
