### PR TITLE
Increase max number redirects of HTTP redirects

### DIFF
--- a/packages/uxpin-merge-cli/package.json
+++ b/packages/uxpin-merge-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxpin/merge-cli",
-  "version": "3.0.5-debug-mode",
+  "version": "3.0.5-debug-http-redirects",
   "description": "The Command-line tool integrates the Design System repository with: https://www.uxpin.com/merge",
   "repository": {
     "type": "git",

--- a/packages/uxpin-merge-cli/package.json
+++ b/packages/uxpin-merge-cli/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@types/babel-core": "^6.25.2",
     "@types/commander": "^2.12.2",
+    "@types/debug": "^4.1.8",
     "@types/formidable": "^1.0.31",
     "@types/fs-extra": "^5.0.4",
     "@types/jest": "29.5.1",
@@ -109,6 +110,7 @@
     "clean-stacktrace": "^1.1.0",
     "clean-stacktrace-relative-paths": "^1.0.4",
     "commander": "^2.11.0",
+    "debug": "^4.3.4",
     "form-data": "^4.0.0",
     "formidable": "^1.2.1",
     "fs-extra": "^7.0.0",
@@ -124,6 +126,7 @@
     "p-map-series": "^1.0.0",
     "p-reduce": "^1.0.0",
     "path-sort": "^0.1.0",
+    "pretty-bytes": "5.6.0",
     "react-docgen": "^4.1.0",
     "require1k": "^1.0.1",
     "sortobject": "^1.1.1",

--- a/packages/uxpin-merge-cli/package.json
+++ b/packages/uxpin-merge-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxpin/merge-cli",
-  "version": "3.0.5",
+  "version": "3.0.5-debug-mode",
   "description": "The Command-line tool integrates the Design System repository with: https://www.uxpin.com/merge",
   "repository": {
     "type": "git",

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/postPushMetadata.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/postPushMetadata.ts
@@ -1,8 +1,11 @@
 import { AxiosResponse } from 'axios';
+import debug from 'debug';
 import { DSMetadata } from '../../../program/DSMeta';
 import { axiosWithEnhancedError } from '../../../utils/axiosWithEnhancedError';
 import { getAuthHeaders } from './headers/getAuthHeaders';
 import { getUserAgentHeaders } from './headers/getUserAgentHeaders';
+
+const log = debug('uxpin');
 
 export interface PushMetadataResponse {
   message: string;
@@ -13,6 +16,13 @@ export async function postPushMetadata(
   token: string,
   metadata: DSMetadata
 ): Promise<PushMetadataResponse | null> {
+  log(
+    `Push component metadata`,
+    metadata.result.name,
+    `${metadata.result.categorizedComponents.length} components: ${metadata.result.categorizedComponents.map(
+      (component) => component.name
+    )}`
+  );
   return axiosWithEnhancedError({
     data: metadata.result,
     headers: {

--- a/packages/uxpin-merge-cli/src/common/services/UXPin/postUploadBundle.ts
+++ b/packages/uxpin-merge-cli/src/common/services/UXPin/postUploadBundle.ts
@@ -1,9 +1,14 @@
 import { AxiosResponse } from 'axios';
+import debug from 'debug';
 import * as FormData from 'form-data';
-import { createReadStream } from 'fs';
+import prettyBytes = require('pretty-bytes');
+import { createReadStream, statSync } from 'fs';
+
 import { axiosWithEnhancedError } from '../../../utils/axiosWithEnhancedError';
 import { getAuthHeaders } from './headers/getAuthHeaders';
 import { getUserAgentHeaders } from './headers/getUserAgentHeaders';
+
+const log = debug('uxpin');
 
 export interface UploadBundleResponse {
   url: string;
@@ -16,7 +21,9 @@ export async function postUploadBundle(
   path: string
 ): Promise<UploadBundleResponse | null> {
   const formData: FormData = new FormData();
+
   formData.append('commitHash', commitHash);
+  log('Uploading', getFileSize(path), path);
   formData.append('bundle', createReadStream(path));
 
   return axiosWithEnhancedError({
@@ -30,4 +37,11 @@ export async function postUploadBundle(
     responseType: 'json',
     url: `${domain}/code/v/1.0/push/bundle`,
   }).then((response: AxiosResponse) => (response.data as UploadBundleResponse) || null);
+}
+
+function getFileSize(filepath: string) {
+  const stats = statSync(filepath);
+  const sizeInBytes = stats.size;
+  const humanReadableSize = prettyBytes(sizeInBytes);
+  return humanReadableSize;
 }

--- a/packages/uxpin-merge-cli/src/program/command/push/steps/uploadLibrary.ts
+++ b/packages/uxpin-merge-cli/src/program/command/push/steps/uploadLibrary.ts
@@ -151,7 +151,7 @@ async function updateRepositoryPointerWithPrintMessage(opts: {
     // Update the repository pointer to point to the new branch
     await updateRepositoryPointerToBranch(opts);
 
-    printLine(`🛈  Projects using this Design System have been updated to branch [${opts.branch}]`, {
+    printLine(`√ Projects using this Design System have been updated to branch [${opts.branch}]`, {
       color: PrintColor.CYAN,
     });
   } catch (error) {

--- a/packages/uxpin-merge-cli/src/program/utils/printSerializationWarnings.ts
+++ b/packages/uxpin-merge-cli/src/program/utils/printSerializationWarnings.ts
@@ -3,5 +3,7 @@ import { Warned } from '../../common/warning/Warned';
 import { DesignSystemSnapshot } from '../../steps/serialization/DesignSystemSnapshot';
 
 export function printSerializationWarnings({ warnings }: Warned<DesignSystemSnapshot>): void {
-  console.log(stringifyWarnings(warnings));
+  if (warnings.length > 0) {
+    console.log(stringifyWarnings(warnings));
+  }
 }

--- a/packages/uxpin-merge-cli/src/steps/building/buildDesignSystem.ts
+++ b/packages/uxpin-merge-cli/src/steps/building/buildDesignSystem.ts
@@ -1,10 +1,15 @@
+import debug from 'debug';
 import { ComponentDefinition } from '../serialization/component/ComponentDefinition';
 import { BuildOptions } from './BuildOptions';
 import { getCompiler } from './compiler/getCompiler';
 import { createComponentsLibrary } from './library/createComponentsLibrary';
 
+const log = debug('uxpin');
+
 export async function buildDesignSystem(components: ComponentDefinition[], options: BuildOptions): Promise<void> {
+  log(`Create component library (${components.length} components)...`);
   await createComponentsLibrary(components, options);
+  log('Bundle design system library with Webpack...');
   await bundle(options);
 }
 

--- a/packages/uxpin-merge-cli/src/steps/building/compiler/webpack/WebpackCompiler.ts
+++ b/packages/uxpin-merge-cli/src/steps/building/compiler/webpack/WebpackCompiler.ts
@@ -1,7 +1,11 @@
+import debug from 'debug';
+import prettyBytes = require('pretty-bytes');
+import * as path from 'path';
 import * as webpack from 'webpack';
 import { formatWebpackErrorMessages } from '../../../../utils/webpack/formatWebpackErrorMessages';
 import { Compiler } from '../Compiler';
 
+const log = debug('uxpin:webpack');
 export class WebpackCompiler implements Compiler {
   private compiler: webpack.Compiler;
 
@@ -10,11 +14,14 @@ export class WebpackCompiler implements Compiler {
   }
 
   public compile(): Promise<void> {
+    log(`Compile with Webpack ${webpack.version} ${logInput(this.config)}`);
     return new Promise((resolve, reject) => {
       this.compiler.run((err, stats) => {
         if (err) {
           return reject(err);
         }
+
+        if (stats) logOutput(stats);
 
         if (stats?.hasErrors()) {
           return reject(new Error(formatWebpackErrorMessages(stats)));
@@ -24,4 +31,25 @@ export class WebpackCompiler implements Compiler {
       });
     });
   }
+}
+
+function logInput(config: webpack.Configuration) {
+  const entries = config.entry;
+  if (Array.isArray(entries)) return (entries as string[]).map(getFilename).join(', ');
+  if (typeof entries === 'string') return getFilename(entries as string);
+  return '';
+}
+
+function logOutput(stats: webpack.Stats) {
+  const assets = stats.toJson().assets || [];
+  log(`Output ${assets.map(logAssetSummary).join(', ')}`);
+}
+
+function logAssetSummary(asset: { name: string; size: number }) {
+  // TODO: Webpack does not export `StatAsset` type?
+  return asset.name + ': ' + prettyBytes(asset.size);
+}
+
+function getFilename(filepath: string) {
+  return path.parse(filepath).base;
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/getComponentMetadata.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/getComponentMetadata.ts
@@ -1,8 +1,11 @@
+import debug from 'debug';
 import { ComponentImplementationInfo, TypeScriptConfig } from '../../../discovery/component/ComponentInfo';
 import { thunkGetSummaryResultForInvalidComponent } from './getSummaryResultForInvalidComponent';
 import { ImplSerializationResult } from './ImplSerializationResult';
 import { serializeJSComponent } from './javascript/serializeJSComponent';
 import { serializeTSComponent } from './typescript/serializeTSComponent';
+
+const log = debug('uxpin:serialization');
 
 export function getComponentMetadata(
   component: ComponentImplementationInfo,
@@ -10,8 +13,10 @@ export function getComponentMetadata(
 ): Promise<ImplSerializationResult> {
   let promise: Promise<ImplSerializationResult>;
   if (component.lang === 'typescript') {
+    log(`Serialize TS component`, component.path);
     promise = serializeTSComponent(component, config);
   } else {
+    log(`Serialize JS component`, component.path);
     promise = serializeJSComponent(component);
   }
   return promise.catch(thunkGetSummaryResultForInvalidComponent(component.path));

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/presets/jsx/compile/compilePresets.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/presets/jsx/compile/compilePresets.ts
@@ -1,3 +1,4 @@
+import debug from 'debug';
 import { unlink } from 'fs-extra';
 import { join, parse } from 'path';
 import * as webpack from 'webpack';
@@ -11,9 +12,14 @@ import { createBundleSource } from '../bundle/createBundleSource';
 import { generateVirtualModules, VirtualComponentModule } from './generateVirtualModules';
 import { getPresetsBundleWebpackConfig } from './getPresetsBundleWebpackConfig';
 
+const log = debug('uxpin:serialization:presets');
+
 export async function compilePresets(programArgs: ProgramArgs, components: ComponentDefinition[]): Promise<string> {
+  log('Create temporary bundle');
   const sourcePath: string = await createBundleSource(programArgs, components);
+  log(`Compile presets with Webpack (${components.length} components)`);
   const bundlePath: string = await compileWithWebpack(programArgs, components, sourcePath);
+  log('Compilation OK, delete temporary bundle');
   await unlink(sourcePath);
 
   return bundlePath;
@@ -38,6 +44,7 @@ async function compileWithWebpack(
     virtualModules,
     webpackConfig,
   });
+
   const compiler: Compiler = new WebpackCompiler(config);
   await compiler.compile();
 

--- a/packages/uxpin-merge-cli/src/steps/serialization/vcs/getVcsDetails.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/vcs/getVcsDetails.ts
@@ -1,3 +1,4 @@
+import debug from 'debug';
 import { getApiDomain } from '../../../common/services/UXPin/getApiDomain';
 import { getLatestCommitHash } from '../../../common/services/UXPin/getLatestCommitHash';
 import { BuildOptions } from '../../../steps/building/BuildOptions';
@@ -8,6 +9,8 @@ import { filterMovedFiles } from './filterMovedFiles';
 import { getRepositoryAdapter } from './repositories/getRepositoryAdapter';
 import { RepositoryAdapter, RepositoryPointer } from './repositories/RepositoryAdapter';
 import { Command } from '../../../program/command/Command';
+
+const log = debug('uxpin');
 
 export async function getVcsDetails(
   paths: ProjectPaths,
@@ -20,6 +23,7 @@ export async function getVcsDetails(
   let latestCommitHash: string | null = null;
 
   if (buildOptions.token && shouldGetLatestCommitHash) {
+    log(`Fetch latest commit hash`);
     latestCommitHash = await getLatestCommitHash(
       getApiDomain(buildOptions.uxpinApiDomain!),
       repositoryPointer.branchName,
@@ -33,6 +37,8 @@ export async function getVcsDetails(
     paths,
   };
 
+  log(`Latest commit`, vcs.branchName, vcs.commitHash);
+
   if (latestCommitHash) {
     const movedFiles: MovedFilePathsMap = await repositoryAdapter.getMovedFiles(
       latestCommitHash,
@@ -43,6 +49,7 @@ export async function getVcsDetails(
       components: filterMovedFiles(movedFiles, categorizedComponents),
       diffSourceCommitHash: latestCommitHash,
     };
+    if (Object.keys(movedFiles).length) log(`Moved files`, Object.keys(movedFiles).length);
   }
 
   return vcs;

--- a/packages/uxpin-merge-cli/src/utils/axiosWithEnhancedError.ts
+++ b/packages/uxpin-merge-cli/src/utils/axiosWithEnhancedError.ts
@@ -7,7 +7,7 @@ export async function axiosWithEnhancedError(options: AxiosRequestConfig): Axios
   log((options.method || 'GET').toUpperCase(), options.url);
   try {
     const result = await axios(options);
-    log(result.status + ' ' + result.statusText)
+    log(result.status + ' ' + result.statusText);
     return result;
   } catch (error) {
     if ((error as AxiosError).response) {

--- a/packages/uxpin-merge-cli/src/utils/axiosWithEnhancedError.ts
+++ b/packages/uxpin-merge-cli/src/utils/axiosWithEnhancedError.ts
@@ -1,14 +1,22 @@
 import axios, { AxiosError, AxiosPromise, AxiosRequestConfig } from 'axios';
+import debug from 'debug';
 
-export function axiosWithEnhancedError(options: AxiosRequestConfig): AxiosPromise {
-  return axios(options).catch((error: AxiosError) => {
-    if (error.response) {
+const log = debug('uxpin:http');
+
+export async function axiosWithEnhancedError(options: AxiosRequestConfig): AxiosPromise {
+  log((options.method || 'GET').toUpperCase(), options.url);
+  try {
+    const result = await axios(options);
+    log(result.status + ' ' + result.statusText)
+    return result;
+  } catch (error) {
+    if ((error as AxiosError).response) {
       throw {
-        ...(error.response.data as any),
+        ...((error as AxiosError)?.response?.data as any),
         url: options.url,
       };
     } else {
       throw error;
     }
-  });
+  }
 }

--- a/packages/uxpin-merge-cli/src/utils/axiosWithEnhancedError.ts
+++ b/packages/uxpin-merge-cli/src/utils/axiosWithEnhancedError.ts
@@ -3,10 +3,14 @@ import debug from 'debug';
 
 const log = debug('uxpin:http');
 
+const defaultOptions: AxiosRequestConfig = {
+  maxRedirects: 10, // override the default limit of `5` to see if it fixes a customer issue
+};
+
 export async function axiosWithEnhancedError(options: AxiosRequestConfig): AxiosPromise {
   log((options.method || 'GET').toUpperCase(), options.url);
   try {
-    const result = await axios(options);
+    const result = await axios({ ...defaultOptions, ...options });
     log(result.status + ' ' + result.statusText);
     return result;
   } catch (error) {

--- a/packages/uxpin-merge-cli/yarn.lock
+++ b/packages/uxpin-merge-cli/yarn.lock
@@ -1857,6 +1857,13 @@
   dependencies:
     commander "*"
 
+"@types/debug@^4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.8.tgz#cef723a5d0a90990313faec2d1e22aee5eecb317"
+  integrity sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==
+  dependencies:
+    "@types/ms" "*"
+
 "@types/eslint-scope@^3.7.0", "@types/eslint-scope@^3.7.3":
   version "3.7.4"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.4.tgz#37fc1223f0786c39627068a12e94d6e6fc61de16"
@@ -1984,6 +1991,11 @@
   integrity sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==
   dependencies:
     "@types/unist" "*"
+
+"@types/ms@*":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
 "@types/node@*":
   version "8.0.31"
@@ -6404,6 +6416,11 @@ prettier@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+
+pretty-bytes@5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
+  integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
 
 pretty-format@^24.9.0:
   version "24.9.0"


### PR DESCRIPTION
## Goal

This is an **attempt** to fix an issue from one of Merge users who have an error about the maximum number of HTTP requests when Merge CLI fetches data about the latest commit.

About Axios options: https://axios-http.com/docs/req_config

I'm sharing here the snippet we want them to run to analyze what is happening when the HTTP request fails, running the `curl` command in verbose mode:

```
curl -v -L https://api.uxpin.com/code/v/1.0/branch/master/latestCommit -H "auth-token: ***"
```

## Screenshot

Customer Output when running the `push` command in debug mode

<img width="761" alt="image" src="https://github.com/UXPin/uxpin-merge-tools/assets/5546996/2bec7b16-1a77-4f4b-94d1-27a6434c986c">


