### PR TITLE
Accept stringified functions for Portal feature to allow dynamic behavior based on props

### DIFF
--- a/packages/uxpin-merge-cli/CHANGELOG.md
+++ b/packages/uxpin-merge-cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.0.7] - 2023-07-11
+
+- Accept a function for `@uxpinuseportal` annotation to make the "Render in Portal" behavior dynamic ([#391](https://github.com/UXPin/uxpin-merge-tools/pull/391))
+
 ## [3.0.6] - 2023-07-05
 
 - Add debug mode using `DEBUG=uxpin*` ([#387](https://github.com/UXPin/uxpin-merge-tools/pull/389))

--- a/packages/uxpin-merge-cli/package.json
+++ b/packages/uxpin-merge-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxpin/merge-cli",
-  "version": "3.0.6",
+  "version": "3.0.6-portal",
   "description": "The Command-line tool integrates the Design System repository with: https://www.uxpin.com/merge",
   "repository": {
     "type": "git",

--- a/packages/uxpin-merge-cli/package.json
+++ b/packages/uxpin-merge-cli/package.json
@@ -102,6 +102,7 @@
     "@types/yargs": "^16.0.0",
     "@uxpin/react-docgen-better-proptypes": "^0.1.1",
     "acorn-loose": "^8.0.2",
+    "acorn-walk": "^8.2.0",
     "ast-types": "^0.12.4",
     "axios": "^1.4.0",
     "babel-loader": "^8.0.5",

--- a/packages/uxpin-merge-cli/package.json
+++ b/packages/uxpin-merge-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxpin/merge-cli",
-  "version": "3.0.6-portal",
+  "version": "3.0.7",
   "description": "The Command-line tool integrates the Design System repository with: https://www.uxpin.com/merge",
   "repository": {
     "type": "git",

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/ComponentDefinition.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/ComponentDefinition.ts
@@ -11,7 +11,7 @@ export interface ComponentMetadata {
   properties: ComponentPropertyDefinition[];
   wrappers?: ComponentWrapper[];
   defaultExported: boolean;
-  usePortal?: boolean;
+  usePortal?: boolean | string;
 }
 
 export interface ComponentDefinition extends ComponentMetadata {

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/comments/__tests__/parseUsePortal.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/comments/__tests__/parseUsePortal.test.ts
@@ -1,0 +1,23 @@
+import { parseAsCondition } from '../parseUsePortal';
+
+describe('Parse string and check valid condition (to be used in a function run against props)', () => {
+  it('Should accept a basic condition', () => {
+    expect(parseAsCondition(`props.mode === "modal"`)).toBe(true);
+  });
+  it('Should accept a more complex condition', () => {
+    expect(parseAsCondition(`props.isValid && props.mode === "modal"`)).toBe(true);
+  });
+  it('Should accept a ternary', () => {
+    expect(parseAsCondition(`props.mode === "modal" ? true : false`)).toBe(true);
+  });
+  it('Should accept a boolean', () => {
+    expect(parseAsCondition(`true`)).toBe(true);
+  });
+
+  it('Should reject a function', () => {
+    expect(parseAsCondition(`function() {}`)).toBe(false);
+  });
+  it(`Should reject random content`, () => {
+    expect(parseAsCondition(`not a condition`)).toBe(false);
+  });
+});

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/comments/__tests__/parseUsePortal.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/comments/__tests__/parseUsePortal.test.ts
@@ -1,23 +1,32 @@
-import { parseAsCondition } from '../parseUsePortal';
+import { ensureIsValidCondition } from '../parseUsePortal';
 
 describe('Parse string and check valid condition (to be used in a function run against props)', () => {
   it('Should accept a basic condition', () => {
-    expect(parseAsCondition(`props.mode === "modal"`)).toBe(true);
+    expect(ensureIsValidCondition(`props.mode === "modal"`)).toBe(true);
   });
   it('Should accept a more complex condition', () => {
-    expect(parseAsCondition(`props.isValid && props.mode === "modal"`)).toBe(true);
+    expect(ensureIsValidCondition(`props.isValid && props.mode === "modal"`)).toBe(true);
   });
   it('Should accept a ternary', () => {
-    expect(parseAsCondition(`props.mode === "modal" ? true : false`)).toBe(true);
+    expect(ensureIsValidCondition(`props.mode === "modal" ? true : false`)).toBe(true);
   });
   it('Should accept a boolean', () => {
-    expect(parseAsCondition(`true`)).toBe(true);
+    expect(ensureIsValidCondition(`true`)).toBe(true);
   });
 
+  it('Should reject an alert()', () => {
+    expect(ensureIsValidCondition(`alert(1) && props.mode === "modal"`)).toBe(false);
+  });
+  it('Should reject expression with multiple body', () => {
+    expect(ensureIsValidCondition(`props.mode === "modal" false`)).toBe(false);
+  });
+  it('Should reject multiple statements', () => {
+    expect(ensureIsValidCondition(`props.isValid && props.mode === "modal"; alert(1)`)).toBe(false);
+  });
   it('Should reject a function', () => {
-    expect(parseAsCondition(`function() {}`)).toBe(false);
+    expect(ensureIsValidCondition(`function() {}`)).toBe(false);
   });
   it(`Should reject random content`, () => {
-    expect(parseAsCondition(`not a condition`)).toBe(false);
+    expect(ensureIsValidCondition(`not a condition`)).toBe(false);
   });
 });

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/comments/getCommentTag.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/comments/getCommentTag.ts
@@ -3,24 +3,3 @@ import { CommentTags } from '../CommentTags';
 export function getCommentTag(tag: CommentTags, tags: string[]): string | undefined {
   return tags.find((line: string) => line.startsWith(tag));
 }
-
-/**
- * Extract from the JSDoc the value related to a given tag, considering only the first line.
- * Added for `@uxpinuseportal` that expects an expression such as `props.mode === "inline"`
- */
-export function getCommentTagRawValue(tag: CommentTags, tags: string[]) {
-  const description = getCommentTag(tag, tags);
-
-  if (!description) {
-    return;
-  }
-
-  const firstLine = description.split('\n')[0];
-  const inlineValue: string | undefined = firstLine.slice(tag.length).trim();
-
-  if (!inlineValue) {
-    return true;
-  }
-
-  return inlineValue;
-}

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/comments/getCommentTag.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/comments/getCommentTag.ts
@@ -3,3 +3,24 @@ import { CommentTags } from '../CommentTags';
 export function getCommentTag(tag: CommentTags, tags: string[]): string | undefined {
   return tags.find((line: string) => line.startsWith(tag));
 }
+
+/**
+ * Extract from the JSDoc the value related to a given tag, considering only the first line.
+ * Added for `@uxpinuseportal` that expects an expression such as `props.mode === "inline"`
+ */
+export function getCommentTagRawValue(tag: CommentTags, tags: string[]) {
+  const description = getCommentTag(tag, tags);
+
+  if (!description) {
+    return;
+  }
+
+  const firstLine = description.split('\n')[0];
+  const inlineValue: string | undefined = firstLine.slice(tag.length).trim();
+
+  if (!inlineValue) {
+    return true;
+  }
+
+  return inlineValue;
+}

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/comments/parseUsePortal.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/comments/parseUsePortal.ts
@@ -1,0 +1,50 @@
+import acorn = require('acorn-loose');
+
+export function parseUsePortal(tagValue: string) {
+  if (!parseAsCondition(tagValue)) {
+    throw new Error(
+      '@uxpinuseportal annotation should be followed by a valid JavaScript condition using the `props` object'
+    );
+  }
+  return tagValue;
+}
+
+export function parseAsCondition(tagValue: string) {
+  try {
+    const tree = acorn.parse(tagValue, { ecmaVersion: 2020 });
+    return isCondition(tree.body);
+  } catch (error) {
+    throw new Error(`Unable to parse the provided condition: ${tagValue}`);
+  }
+}
+
+function isCondition(body: acorn.ModuleNode['body']) {
+  if (!body) return false;
+  const node = body[0];
+
+  // a === b
+  if (node.type === 'ExpressionStatement' && node.expression.type === 'BinaryExpression') {
+    return true;
+  }
+
+  // a && b
+  if (node.type === 'ExpressionStatement' && node.expression.type === 'LogicalExpression') {
+    return true;
+  }
+
+  // Ternary
+  if (node.type === 'ExpressionStatement' && node.expression.type === 'ConditionalExpression') {
+    return true;
+  }
+
+  // Boolean
+  if (
+    node.type === 'ExpressionStatement' &&
+    node.expression.type === 'Literal' &&
+    ['true', 'false'].includes(node.expression.raw)
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/getSummaryResultForInvalidComponent.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/getSummaryResultForInvalidComponent.ts
@@ -1,11 +1,17 @@
+import debug from 'debug';
+
 import { WarningDetails } from '../../../../common/warning/WarningDetails';
 import { ComponentMetadata } from '../ComponentDefinition';
 import { getComponentNameFromPath } from '../name/getComponentNameFromPath';
 import { ImplSerializationResult } from './ImplSerializationResult';
 import { isDefaultExported } from './javascript/isDefaultExported';
 
+const log = debug('uxpin:serialization:error');
+
 export function thunkGetSummaryResultForInvalidComponent(sourcePath: string): (e: Error) => ImplSerializationResult {
   return (originalError) => {
+    log(sourcePath, originalError.message);
+
     const warning: WarningDetails = {
       message: 'Cannot serialize component properties',
       originalError,

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/getComponentUsePortalFromJsDocTags.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/getComponentUsePortalFromJsDocTags.ts
@@ -1,0 +1,25 @@
+import { getCommentTag } from '../../comments/getCommentTag';
+import { parseUsePortal } from '../../comments/parseUsePortal';
+import { CommentTags } from '../../CommentTags';
+
+/**
+ * Extract the value for `@uxpinuseportal` annotation from all JSDoc annotations
+ *  can be either undefined (not found), true (found with no value) or a condition such as `props.mode === "inline"`
+ */
+export function getComponentUsePortalFromJsDocTags(jsDocTags: string[]) {
+  const tagName = CommentTags.UXPIN_USE_PORTAL;
+  const description = getCommentTag(tagName, jsDocTags);
+
+  if (!description) {
+    return;
+  }
+
+  const firstLine = description.split('\n')[0];
+  const inlineValue: string | undefined = firstLine.slice(tagName.length).trim();
+
+  if (!inlineValue) {
+    return true;
+  }
+
+  return parseUsePortal(inlineValue);
+}

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/isDefaultExported.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/isDefaultExported.ts
@@ -4,6 +4,7 @@ import {
   ExportDefaultDeclaration,
   ExportNamedDeclaration,
   ExportSpecifier,
+  ExpressionStatement,
   FunctionDeclaration,
   Identifier,
   ImportDeclaration,
@@ -27,7 +28,7 @@ export function isDefaultExported(componentPath: string, name: string): boolean 
     return false;
   }
 
-  type nodeTypes = ExportDefaultDeclaration | ExportNamedDeclaration | ImportDeclaration;
+  type nodeTypes = ExportDefaultDeclaration | ExportNamedDeclaration | ImportDeclaration | ExpressionStatement;
   let isNamedExported = false;
   let exportDefaultDeclaration: ExportDefaultDeclaration | undefined;
 

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/serializeJSComponent.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/serializeJSComponent.ts
@@ -4,7 +4,7 @@ import { joinWarningLists } from '../../../../../common/warning/joinWarningLists
 import { Warned } from '../../../../../common/warning/Warned';
 import { ComponentImplementationInfo } from '../../../../discovery/component/ComponentInfo';
 import { validateWrappers } from '../../../validation/validateWrappers';
-import { getCommentTag } from '../../comments/getCommentTag';
+import { getCommentTag, getCommentTagRawValue } from '../../comments/getCommentTag';
 import { getJSDocTagsArrayFromString } from '../../comments/getJSDocTagsArrayFromString';
 import { CommentTags } from '../../CommentTags';
 import { ComponentNamespace } from '../../ComponentDefinition';
@@ -71,7 +71,11 @@ function getValuesFromComments(
 
   const namespace: ComponentNamespace | undefined = getComponentNamespaceFromDescription(name, namespaceTag);
   const componentDocUrl: string | undefined = getComponentDocUrlFromDescription(componentDocUrlTag);
-  const usePortal: boolean | undefined = !!getCommentTag(CommentTags.UXPIN_USE_PORTAL, jsDocTags) || undefined;
+
+  const usePortal: boolean | string | undefined = getCommentTagRawValue(CommentTags.UXPIN_USE_PORTAL, jsDocTags);
+
+  console.log({usePortal});
+
   return { namespace, componentDocUrl, usePortal };
 }
 
@@ -93,5 +97,5 @@ interface PartialResult {
   properties: PropDefinitionSerializationResult[];
   wrappers: Warned<ComponentWrapper[]>;
   defaultExported: boolean;
-  usePortal?: boolean;
+  usePortal?: boolean | string;
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/serializeJSComponent.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/serializeJSComponent.ts
@@ -23,7 +23,7 @@ import { getDefaultComponentFrom } from './getDefaultComponentFrom';
 import { isDefaultExported } from './isDefaultExported';
 import { parsePropertyItem } from './parsePropertyItem';
 
-const log = debug('uxpin:serialization')
+const log = debug('uxpin:serialization');
 
 export function serializeJSComponent(component: ComponentImplementationInfo): Promise<ImplSerializationResult> {
   return getDefaultComponentFrom(component.path)

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/serializeJSComponent.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/serializeJSComponent.ts
@@ -24,7 +24,7 @@ import { getDefaultComponentFrom } from './getDefaultComponentFrom';
 import { isDefaultExported } from './isDefaultExported';
 import { parsePropertyItem } from './parsePropertyItem';
 
-const log = debug('uxpin:serialization');
+const log = debug('uxpin:serialization:js');
 
 export function serializeJSComponent(component: ComponentImplementationInfo): Promise<ImplSerializationResult> {
   return getDefaultComponentFrom(component.path)

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/serializeJSComponent.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/serializeJSComponent.ts
@@ -6,7 +6,7 @@ import { joinWarningLists } from '../../../../../common/warning/joinWarningLists
 import { Warned } from '../../../../../common/warning/Warned';
 import { ComponentImplementationInfo } from '../../../../discovery/component/ComponentInfo';
 import { validateWrappers } from '../../../validation/validateWrappers';
-import { getCommentTag, getCommentTagRawValue } from '../../comments/getCommentTag';
+import { getCommentTag } from '../../comments/getCommentTag';
 import { getJSDocTagsArrayFromString } from '../../comments/getJSDocTagsArrayFromString';
 import { CommentTags } from '../../CommentTags';
 import { ComponentNamespace } from '../../ComponentDefinition';
@@ -19,6 +19,7 @@ import { PropDefinitionSerializationResult } from '../PropDefinitionSerializatio
 import { getComponentDocUrlFromDescription } from './getComponentDocUrlFromDescription';
 import { getComponentName } from './getComponentName';
 import { getComponentNamespaceFromDescription } from './getComponentNamespaceFromDescription';
+import { getComponentUsePortalFromJsDocTags } from './getComponentUsePortalFromJsDocTags';
 import { getDefaultComponentFrom } from './getDefaultComponentFrom';
 import { isDefaultExported } from './isDefaultExported';
 import { parsePropertyItem } from './parsePropertyItem';
@@ -76,7 +77,7 @@ function getValuesFromComments(
   const namespace: ComponentNamespace | undefined = getComponentNamespaceFromDescription(name, namespaceTag);
   const componentDocUrl: string | undefined = getComponentDocUrlFromDescription(componentDocUrlTag);
 
-  const usePortal: boolean | string | undefined = getCommentTagRawValue(CommentTags.UXPIN_USE_PORTAL, jsDocTags);
+  const usePortal: boolean | string | undefined = getComponentUsePortalFromJsDocTags(jsDocTags);
   if (usePortal) log(`Portal component detected`, name, usePortal);
 
   return { namespace, componentDocUrl, usePortal };

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/serializeJSComponent.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/serializeJSComponent.ts
@@ -1,5 +1,7 @@
+import debug from 'debug';
 import { toPairs } from 'lodash';
 import { ComponentDoc } from 'react-docgen-typescript/lib';
+
 import { joinWarningLists } from '../../../../../common/warning/joinWarningLists';
 import { Warned } from '../../../../../common/warning/Warned';
 import { ComponentImplementationInfo } from '../../../../discovery/component/ComponentInfo';
@@ -20,6 +22,8 @@ import { getComponentNamespaceFromDescription } from './getComponentNamespaceFro
 import { getDefaultComponentFrom } from './getDefaultComponentFrom';
 import { isDefaultExported } from './isDefaultExported';
 import { parsePropertyItem } from './parsePropertyItem';
+
+const log = debug('uxpin:serialization')
 
 export function serializeJSComponent(component: ComponentImplementationInfo): Promise<ImplSerializationResult> {
   return getDefaultComponentFrom(component.path)
@@ -73,8 +77,7 @@ function getValuesFromComments(
   const componentDocUrl: string | undefined = getComponentDocUrlFromDescription(componentDocUrlTag);
 
   const usePortal: boolean | string | undefined = getCommentTagRawValue(CommentTags.UXPIN_USE_PORTAL, jsDocTags);
-
-  console.log({usePortal});
+  if (usePortal) log(`Portal component detected`, name, usePortal);
 
   return { namespace, componentDocUrl, usePortal };
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/comments/jsdoc-useportal.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/comments/jsdoc-useportal.ts
@@ -1,3 +1,4 @@
+import { parseUsePortal } from '../../../comments/parseUsePortal';
 import { CommentTags } from '../../../CommentTags';
 import { ComponentDeclaration } from '../component/getPropsTypeAndDefaultProps';
 import { getNodeJsDocTag } from './jsdoc-helpers';
@@ -5,6 +6,6 @@ import { getNodeJsDocTag } from './jsdoc-helpers';
 export function getComponentUsePortal(declaration: ComponentDeclaration) {
   const node = getNodeJsDocTag(declaration, CommentTags.UXPIN_USE_PORTAL);
   if (!node) return undefined;
-  if (node.comment) return node.comment as string;
+  if (node.comment) return parseUsePortal(node.comment as string);
   return Boolean(node);
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/comments/jsdoc-useportal.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/comments/jsdoc-useportal.ts
@@ -4,5 +4,7 @@ import { getNodeJsDocTag } from './jsdoc-helpers';
 
 export function getComponentUsePortal(declaration: ComponentDeclaration) {
   const node = getNodeJsDocTag(declaration, CommentTags.UXPIN_USE_PORTAL);
+  if (!node) return undefined;
+  if (node.comment) return node.comment as string;
   return Boolean(node);
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/serializeTSComponent.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/serializeTSComponent.ts
@@ -1,3 +1,5 @@
+import debug from 'debug';
+
 import { joinWarningLists } from '../../../../../common/warning/joinWarningLists';
 import { Warned } from '../../../../../common/warning/Warned';
 import { ComponentImplementationInfo, TypeScriptConfig } from '../../../../discovery/component/ComponentInfo';
@@ -19,6 +21,8 @@ import { isDefaultExported } from './component/isDefaultExported';
 import { getSerializationContext, TSSerializationContext } from './context/getSerializationContext';
 import { parseTSComponentProperties } from './parseTSComponentProperties';
 
+const log = debug('uxpin:serialize');
+
 export async function serializeTSComponent(
   component: ComponentImplementationInfo,
   config?: TypeScriptConfig
@@ -38,10 +42,9 @@ export async function serializeTSComponent(
   const wrappers: ComponentWrapper[] = getComponentWrappers(declaration);
   const validatedWrappers: Warned<ComponentWrapper[]> = validateWrappers(wrappers, component);
   const defaultExported: boolean = isDefaultExported(declaration, context);
+
   const usePortal = getComponentUsePortal(declaration) || undefined;
-
-  console.log({usePortal});
-
+  if (usePortal) log(`Portal component detected`, name, usePortal);
 
   return {
     result: {

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/serializeTSComponent.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/serializeTSComponent.ts
@@ -21,7 +21,7 @@ import { isDefaultExported } from './component/isDefaultExported';
 import { getSerializationContext, TSSerializationContext } from './context/getSerializationContext';
 import { parseTSComponentProperties } from './parseTSComponentProperties';
 
-const log = debug('uxpin:serialize');
+const log = debug('uxpin:serialization:ts');
 
 export async function serializeTSComponent(
   component: ComponentImplementationInfo,

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/serializeTSComponent.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/serializeTSComponent.ts
@@ -38,7 +38,10 @@ export async function serializeTSComponent(
   const wrappers: ComponentWrapper[] = getComponentWrappers(declaration);
   const validatedWrappers: Warned<ComponentWrapper[]> = validateWrappers(wrappers, component);
   const defaultExported: boolean = isDefaultExported(declaration, context);
-  const usePortal: boolean | undefined = getComponentUsePortal(declaration) || undefined;
+  const usePortal = getComponentUsePortal(declaration) || undefined;
+
+  console.log({usePortal});
+
 
   return {
     result: {

--- a/packages/uxpin-merge-cli/src/types/acorn-loose.d.ts
+++ b/packages/uxpin-merge-cli/src/types/acorn-loose.d.ts
@@ -4,7 +4,7 @@ import { Node, Options } from 'acorn';
 export declare function parse(code: string, opts?: Options): ModuleNode;
 
 export interface ModuleNode extends Node {
-  body?: (ImportDeclaration | ExportDefaultDeclaration)[];
+  body?: (ImportDeclaration | ExportDefaultDeclaration | ExpressionStatement)[];
 }
 
 export interface ExportDefaultDeclaration extends Node {
@@ -90,4 +90,12 @@ export interface VariableDeclarator extends Node {
 export interface CallExpression extends Node {
   type: 'CallExpression';
   arguments: (Identifier | CallExpression)[];
+}
+
+export interface ExpressionStatement extends Node {
+  type: 'ExpressionStatement';
+  expression: {
+    type: string;
+    raw: string;
+  };
 }

--- a/packages/uxpin-merge-cli/src/types/acorn-loose.d.ts
+++ b/packages/uxpin-merge-cli/src/types/acorn-loose.d.ts
@@ -87,9 +87,14 @@ export interface VariableDeclarator extends Node {
   id: Identifier;
 }
 
+// The 2 following types were added when implementing the parsing of @uxpinuseportal
+// TODO we should not have to add the types by ourselves
 export interface CallExpression extends Node {
   type: 'CallExpression';
   arguments: (Identifier | CallExpression)[];
+  callee: {
+    name: string;
+  };
 }
 
 export interface ExpressionStatement extends Node {

--- a/packages/uxpin-merge-cli/yarn.lock
+++ b/packages/uxpin-merge-cli/yarn.lock
@@ -2536,6 +2536,11 @@ acorn-loose@^8.0.2:
   dependencies:
     acorn "^8.0.0"
 
+acorn-walk@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^8.0.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.1.0.tgz#52311fd7037ae119cbb134309e901aa46295b3fe"


### PR DESCRIPTION
## Goal

Since https://github.com/UXPin/uxpin-merge-tools/pull/346 it's possible to make the components render in a React Portal by adding a specific `@uxpinuseportal` annotation. 

DXC customer wants to apply the behavior in a dynamic way, depending on the `props` of the component: their `Alert` component accepts a `mode` props that can be either `inline` or `modal`. The Portal behavior should apply to the `modal` mode only.

https://developer.dxc.com/halstack/9/components/alert/

This PR lets users define a function that takes the component `props` as the argument and returns whether or not the component should be rendered in a Portal.

```js
props => props.mode === "modal"
```

To make things shorter, the user provides only the function body: `props.mode === "modal"`:

```js
/**
 * @uxpinuseportal props.message === "modal"
 */
```

How it's handled in the engine (hint in 4 letters: `eval` 😅 ) https://github.com/UXPin/uxpin-engine/pull/2557

## Unit tests

```
 npx jest /src/steps/serialization/component/comments/__tests__/parseUsePortal.test.ts
```

## How to check

- Run the experimental mode in DXC repo: https://github.com/uxpin-merge/halstack-uxpin-merge
- Using the JSDoc annotation mentioned above for `Alert` component
- In debug mode, check that portal was detected correctly.

![image](https://github.com/UXPin/uxpin-merge-tools/assets/5546996/a51a78fc-a81e-4355-9358-effd6d6fbb0f)


