### PR TITLE
Handle boolean `true` and `false` for `@uxpinuseportal` annotation

### DIFF
--- a/packages/uxpin-merge-cli/CHANGELOG.md
+++ b/packages/uxpin-merge-cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [3.0.7] - 2023-07-11
+## [3.1.0] - 2023-07-11
 
 - Accept a function for `@uxpinuseportal` annotation to make the "Render in Portal" behavior dynamic ([#391](https://github.com/UXPin/uxpin-merge-tools/pull/391))
 

--- a/packages/uxpin-merge-cli/package.json
+++ b/packages/uxpin-merge-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxpin/merge-cli",
-  "version": "3.0.7",
+  "version": "3.1.0",
   "description": "The Command-line tool integrates the Design System repository with: https://www.uxpin.com/merge",
   "repository": {
     "type": "git",

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/comments/parseUsePortal.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/comments/parseUsePortal.ts
@@ -5,6 +5,9 @@ import debug from 'debug';
 const log = debug('uxpin:serialization:jsdoc-parsing');
 
 export function parseUsePortal(tagValue: string) {
+  if (tagValue.toLowerCase() === 'false') return false;
+  if (tagValue.toLowerCase() === 'true') return true;
+
   if (!ensureIsValidCondition(tagValue)) {
     throw new Error(
       '@uxpinuseportal annotation should be followed by a valid JavaScript condition using the `props` object'

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent-usePortal.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent-usePortal.test.ts
@@ -5,13 +5,37 @@ import { serializeTSComponent } from '../serializeTSComponent';
 import { getImplementation } from './serializeTSComponent.test';
 
 describe('serializeTSComponent-usePortal', () => {
-  it('is serialized with `usePortal` property', async () => {
+  it('is serialized with `usePortal` property set to the boolean `true`', async () => {
     // having
-    const component: ComponentImplementationInfo = getImplementation('FunctionWithUsePortalDeclaration');
+    const component: ComponentImplementationInfo = getImplementation('FunctionWithUsePortalDeclarationBoolean');
     const expectedMetadata: ComponentMetadata = {
       defaultExported: true,
       usePortal: true,
-      name: 'FunctionWithUsePortalDeclaration',
+      name: 'FunctionWithUsePortalDeclarationBoolean',
+      properties: [
+        {
+          description: '',
+          isRequired: true,
+          name: 'name',
+          type: { name: 'string', structure: {} },
+        },
+      ],
+      wrappers: [],
+    };
+
+    // when
+    const metadata: Warned<ComponentMetadata> = await serializeTSComponent(component);
+    // then
+    expect(metadata.warnings).toEqual([]);
+    expect(metadata.result).toEqual(expectedMetadata);
+  });
+  it('is serialized with `usePortal` property set to a string', async () => {
+    // having
+    const component: ComponentImplementationInfo = getImplementation('FunctionWithUsePortalDeclarationString');
+    const expectedMetadata: ComponentMetadata = {
+      defaultExported: true,
+      usePortal: `props.mode === "modal"`,
+      name: 'FunctionWithUsePortalDeclarationString',
       properties: [
         {
           description: '',

--- a/packages/uxpin-merge-cli/test/resources/components/typescript/FunctionWithUsePortalDeclarationBoolean.tsx
+++ b/packages/uxpin-merge-cli/test/resources/components/typescript/FunctionWithUsePortalDeclarationBoolean.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+export interface Props {
+  name: string;
+}
+
+/**
+ * @uxpinuseportal
+ */
+export default function FunctionWithUsePortalDeclarationBoolean({ name }: Props): JSX.Element {
+  return (
+    <div>
+      <label className={name}>{name}</label>
+    </div>
+  );
+}

--- a/packages/uxpin-merge-cli/test/resources/components/typescript/FunctionWithUsePortalDeclarationString.tsx
+++ b/packages/uxpin-merge-cli/test/resources/components/typescript/FunctionWithUsePortalDeclarationString.tsx
@@ -5,9 +5,9 @@ export interface Props {
 }
 
 /**
- * @uxpinuseportal
+ * @uxpinuseportal props.mode === "modal"
  */
-export default function FunctionWithUsePortalDeclaration({ name }: Props): JSX.Element {
+export default function FunctionWithUsePortalDeclarationString({ name }: Props): JSX.Element {
   return (
     <div>
       <label className={name}>{name}</label>


### PR DESCRIPTION
## Goal

Following the change introduced here #391 , I noticed when doing testing that the boolean `true` and `false` were not handled correctly as they were saved as string.

Instead we should handle them as boolean. Doing this:

- `@uxpinuseportal true` means the same thing as `@uxpinuseportal`
- `@uxpinuseportal false` means the same thing as no annotation at all
 
## How to check

Run the experimental mode in DXC repo: https://github.com/uxpin-merge/halstack-uxpin-merge

In debug mode, check that portal is set to true when using the annotation `@uxpinuseportal` or `@uxpinuseportal true`

![image](https://github.com/UXPin/uxpin-merge-tools/assets/5546996/26425db5-5e1f-4364-ac41-ae071a317fea)

In debug mode, check that no portal feature is detected when using the annotation `@uxpinuseportal false`

## Unit tests

```
npx jest src/steps/serialization/component/implementation/typescript/__tests__/serializeTSComponent-usePortal.test.ts 
```

![image](https://github.com/UXPin/uxpin-merge-tools/assets/5546996/e51796a1-5df9-492f-bc1e-2f2525c8cd06)

Note: there is something wrong with the setup of the serialization test as the previous command runs all the serialization tests ("36 passed") instead of only the 2 tests inside `serializeTSComponent-usePortal.test.ts `, it will be fixed in another PR.
