### PR TITLE
Let users inject custom content in page `<head>`

### DIFF
--- a/packages/uxpin-merge-cli/CHANGELOG.md
+++ b/packages/uxpin-merge-cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.3.0] - 2023-08-01
+
+- Let users inject HTML tags in page `<head>` ([#398](https://github.com/UXPin/uxpin-merge-tools/pull/401))
+
 ## [3.2.0] - 2023-07-20
 
 - Faster serialization of TS components ([#398](https://github.com/UXPin/uxpin-merge-tools/pull/398))

--- a/packages/uxpin-merge-cli/package.json
+++ b/packages/uxpin-merge-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxpin/merge-cli",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "The Command-line tool integrates the Design System repository with: https://www.uxpin.com/merge",
   "repository": {
     "type": "git",

--- a/packages/uxpin-merge-cli/src/program/args/ProgramArgs.ts
+++ b/packages/uxpin-merge-cli/src/program/args/ProgramArgs.ts
@@ -11,7 +11,7 @@ export interface RawProgramArgs {
 }
 
 export interface ConfigEnabledProgramArgs {
-  pageHeadContent?: string | string[];
+  pageHeadTags?: string | string[];
   webpackConfig?: string;
   wrapper?: string;
   uxpinDomain?: string;
@@ -38,7 +38,7 @@ export interface ExperimentProgramArgs {
   config: string;
   cwd: string;
   disableTunneling?: boolean;
-  pageHeadContent?: string[];
+  pageHeadTags?: string[];
   port: number;
   webpackConfig?: string;
   wrapper?: string;

--- a/packages/uxpin-merge-cli/src/program/args/ProgramArgs.ts
+++ b/packages/uxpin-merge-cli/src/program/args/ProgramArgs.ts
@@ -11,6 +11,7 @@ export interface RawProgramArgs {
 }
 
 export interface ConfigEnabledProgramArgs {
+  pageHeadContent?: string;
   webpackConfig?: string;
   wrapper?: string;
   uxpinDomain?: string;
@@ -37,6 +38,7 @@ export interface ExperimentProgramArgs {
   config: string;
   cwd: string;
   disableTunneling?: boolean;
+  pageHeadContent?: string;
   port: number;
   webpackConfig?: string;
   wrapper?: string;

--- a/packages/uxpin-merge-cli/src/program/args/ProgramArgs.ts
+++ b/packages/uxpin-merge-cli/src/program/args/ProgramArgs.ts
@@ -11,7 +11,7 @@ export interface RawProgramArgs {
 }
 
 export interface ConfigEnabledProgramArgs {
-  pageHeadContent?: string;
+  pageHeadContent?: string | string[];
   webpackConfig?: string;
   wrapper?: string;
   uxpinDomain?: string;
@@ -38,7 +38,7 @@ export interface ExperimentProgramArgs {
   config: string;
   cwd: string;
   disableTunneling?: boolean;
-  pageHeadContent?: string;
+  pageHeadContent?: string[];
   port: number;
   webpackConfig?: string;
   wrapper?: string;

--- a/packages/uxpin-merge-cli/src/program/args/pickConfigArgs.ts
+++ b/packages/uxpin-merge-cli/src/program/args/pickConfigArgs.ts
@@ -11,7 +11,12 @@ export function pickConfigArgs(configPath: string, command: Command): ConfigEnab
   } else {
     components = getConfiguration(configPath).components;
   }
-  const configFlags: Array<keyof ConfigEnabledProgramArgs> = ['webpackConfig', 'uxpinDomain', 'wrapper'];
+  const configFlags: Array<keyof ConfigEnabledProgramArgs> = [
+    'pageHeadContent',
+    'webpackConfig',
+    'uxpinDomain',
+    'wrapper',
+  ];
 
   return configFlags.reduce<ConfigEnabledProgramArgs>((result, flag) => {
     if (components[flag]) {

--- a/packages/uxpin-merge-cli/src/program/args/pickConfigArgs.ts
+++ b/packages/uxpin-merge-cli/src/program/args/pickConfigArgs.ts
@@ -18,10 +18,29 @@ export function pickConfigArgs(configPath: string, command: Command): ConfigEnab
     'wrapper',
   ];
 
-  return configFlags.reduce<ConfigEnabledProgramArgs>((result, flag) => {
-    if (components[flag]) {
-      result[flag] = components[flag];
+  const config = pickNonEmptyValues<ConfigEnabledProgramArgs>(components, configFlags);
+  return normalizeConfig(config);
+}
+
+function pickNonEmptyValues<T>(input: T, keys: Array<keyof T>) {
+  const result = {} as T;
+  keys.forEach((key) => {
+    const value = input[key];
+    if (value) {
+      result[key] = value;
     }
-    return result;
-  }, {});
+  });
+  return result;
+}
+
+function normalizeConfig(config: ConfigEnabledProgramArgs) {
+  return {
+    ...config,
+    pageHeadContent: makeArray(config.pageHeadContent),
+  };
+}
+
+function makeArray(input: string | string[] | undefined) {
+  if (!input) return [];
+  return Array.isArray(input) ? (input as string[]) : [input];
 }

--- a/packages/uxpin-merge-cli/src/program/args/pickConfigArgs.ts
+++ b/packages/uxpin-merge-cli/src/program/args/pickConfigArgs.ts
@@ -12,7 +12,7 @@ export function pickConfigArgs(configPath: string, command: Command): ConfigEnab
     components = getConfiguration(configPath).components;
   }
   const configFlags: Array<keyof ConfigEnabledProgramArgs> = [
-    'pageHeadContent',
+    'pageHeadTags',
     'webpackConfig',
     'uxpinDomain',
     'wrapper',
@@ -36,7 +36,7 @@ function pickNonEmptyValues<T>(input: T, keys: Array<keyof T>) {
 function normalizeConfig(config: ConfigEnabledProgramArgs) {
   return {
     ...config,
-    pageHeadContent: makeArray(config.pageHeadContent),
+    pageHeadTags: makeArray(config.pageHeadTags),
   };
 }
 

--- a/packages/uxpin-merge-cli/src/program/command/experimentation/steps/experimentationBuildLibraryStep.ts
+++ b/packages/uxpin-merge-cli/src/program/command/experimentation/steps/experimentationBuildLibraryStep.ts
@@ -10,10 +10,11 @@ export function experimentationBuildLibraryStep(args: ExperimentProgramArgs): St
 }
 
 export function getBuildOptions(args: ExperimentProgramArgs): BuildOptions {
-  const { command, webpackConfig, wrapper } = args;
+  const { command, pageHeadContent, webpackConfig, wrapper } = args;
   return {
     command,
     development: true,
+    pageHeadContent,
     projectRoot: getProjectRoot(args),
     uxpinDirPath: getTempDirPath(args),
     webpackConfigPath: webpackConfig,

--- a/packages/uxpin-merge-cli/src/program/command/experimentation/steps/experimentationBuildLibraryStep.ts
+++ b/packages/uxpin-merge-cli/src/program/command/experimentation/steps/experimentationBuildLibraryStep.ts
@@ -10,11 +10,11 @@ export function experimentationBuildLibraryStep(args: ExperimentProgramArgs): St
 }
 
 export function getBuildOptions(args: ExperimentProgramArgs): BuildOptions {
-  const { command, pageHeadContent, webpackConfig, wrapper } = args;
+  const { command, pageHeadTags, webpackConfig, wrapper } = args;
   return {
     command,
     development: true,
-    pageHeadContent,
+    pageHeadTags,
     projectRoot: getProjectRoot(args),
     uxpinDirPath: getTempDirPath(args),
     webpackConfigPath: webpackConfig,

--- a/packages/uxpin-merge-cli/src/program/command/push/getBuildOptions.ts
+++ b/packages/uxpin-merge-cli/src/program/command/push/getBuildOptions.ts
@@ -1,19 +1,19 @@
 import { getDefaultApiDomain } from '../../../../src/common/services/UXPin/getDefaultApiDomain';
 import { BuildOptions } from '../../../steps/building/BuildOptions';
-import { PushProgramArgs } from '../../args/ProgramArgs';
 import { getProjectRoot } from '../../args/providers/paths/getProjectRoot';
 import { getTempDirPath } from '../../args/providers/paths/getTempDirPath';
 import { Command } from '../Command';
 
 export function getBuildOptions(args: BuildProgramArgs): BuildOptions {
-  const { command, token, uxpinDomain, webpackConfig, wrapper, branch, tag, force } = args;
+  const { command, pageHeadContent, token, uxpinDomain, webpackConfig, wrapper, branch, tag, force } = args;
 
   return {
-    command,
     branch,
+    command,
+    force,
+    pageHeadContent,
     projectRoot: getProjectRoot(args),
     tag,
-    force,
     token,
     uxpinApiDomain: getDefaultApiDomain(uxpinDomain!),
     uxpinDirPath: getTempDirPath(args),
@@ -24,14 +24,15 @@ export function getBuildOptions(args: BuildProgramArgs): BuildOptions {
 }
 
 export interface BuildProgramArgs {
+  branch?: string;
   command: Command;
   config?: string;
   cwd: string;
   force?: boolean;
+  pageHeadContent?: string;
+  tag?: string;
   token?: string;
   uxpinDomain?: string;
   webpackConfig?: string;
   wrapper?: string;
-  branch?: string;
-  tag?: string;
 }

--- a/packages/uxpin-merge-cli/src/program/command/push/getBuildOptions.ts
+++ b/packages/uxpin-merge-cli/src/program/command/push/getBuildOptions.ts
@@ -29,7 +29,7 @@ export interface BuildProgramArgs {
   config?: string;
   cwd: string;
   force?: boolean;
-  pageHeadContent?: string;
+  pageHeadContent?: string[];
   tag?: string;
   token?: string;
   uxpinDomain?: string;

--- a/packages/uxpin-merge-cli/src/program/command/push/getBuildOptions.ts
+++ b/packages/uxpin-merge-cli/src/program/command/push/getBuildOptions.ts
@@ -5,13 +5,13 @@ import { getTempDirPath } from '../../args/providers/paths/getTempDirPath';
 import { Command } from '../Command';
 
 export function getBuildOptions(args: BuildProgramArgs): BuildOptions {
-  const { command, pageHeadContent, token, uxpinDomain, webpackConfig, wrapper, branch, tag, force } = args;
+  const { command, pageHeadTags, token, uxpinDomain, webpackConfig, wrapper, branch, tag, force } = args;
 
   return {
     branch,
     command,
     force,
-    pageHeadContent,
+    pageHeadTags,
     projectRoot: getProjectRoot(args),
     tag,
     token,
@@ -29,7 +29,7 @@ export interface BuildProgramArgs {
   config?: string;
   cwd: string;
   force?: boolean;
-  pageHeadContent?: string[];
+  pageHeadTags?: string[];
   tag?: string;
   token?: string;
   uxpinDomain?: string;

--- a/packages/uxpin-merge-cli/src/steps/building/BuildOptions.ts
+++ b/packages/uxpin-merge-cli/src/steps/building/BuildOptions.ts
@@ -5,7 +5,7 @@ export interface BuildOptions {
   branch?: string;
   development?: boolean;
   force?: boolean;
-  pageHeadContent?: string[];
+  pageHeadTags?: string[];
   projectRoot: string;
   tag?: string;
   token?: string;

--- a/packages/uxpin-merge-cli/src/steps/building/BuildOptions.ts
+++ b/packages/uxpin-merge-cli/src/steps/building/BuildOptions.ts
@@ -2,15 +2,16 @@ import { Command } from '../../program/command/Command';
 
 export interface BuildOptions {
   command: Command;
+  branch?: string;
   development?: boolean;
+  force?: boolean;
+  pageHeadContent?: string;
   projectRoot: string;
+  tag?: string;
   token?: string;
   uxpinDirPath: string;
   uxpinApiDomain?: string;
   uxpinDomain?: string;
   webpackConfigPath?: string;
   wrapperPath?: string;
-  branch?: string;
-  tag?: string;
-  force?: boolean;
 }

--- a/packages/uxpin-merge-cli/src/steps/building/BuildOptions.ts
+++ b/packages/uxpin-merge-cli/src/steps/building/BuildOptions.ts
@@ -5,7 +5,7 @@ export interface BuildOptions {
   branch?: string;
   development?: boolean;
   force?: boolean;
-  pageHeadContent?: string;
+  pageHeadContent?: string[];
   projectRoot: string;
   tag?: string;
   token?: string;

--- a/packages/uxpin-merge-cli/src/steps/building/library/__tests__/getLibraryBundleSource.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/building/library/__tests__/getLibraryBundleSource.test.ts
@@ -223,4 +223,57 @@ export {
     // then
     expect(result).toEqual(expectedFileString);
   });
+
+  it('handles `pageHeadTags` option to add a script in the bundle', () => {
+    const components: ComponentDefinition[] = [
+      {
+        defaultExported: true,
+        info: {
+          dirPath: 'src/components/button',
+          implementation: {
+            ...commonImplementation,
+            path: 'src/components/button/button.jsx',
+          },
+        },
+        name: 'Button',
+        ...commonProps,
+      },
+      {
+        defaultExported: true,
+        info: {
+          dirPath: 'src/components/button-list',
+          implementation: {
+            ...commonImplementation,
+            path: 'src/components/button-list/button-list.jsx',
+          },
+        },
+        name: 'ButtonList',
+        ...commonProps,
+      },
+    ];
+
+    const expectedFileString = `import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import Button from '../src/components/button/button';
+import ButtonList from '../src/components/button-list/button-list';
+export {
+  Button,
+  ButtonList,
+  React,
+  ReactDOM,
+};
+
+const template = document.createElement('template');
+template.innerHTML = \`<style>.blue {color: blue;}</style>\`;
+const nodes = Array.from(template.content.children);
+nodes.forEach(node => document.head.prepend(node));
+`;
+
+    // when
+    const pageHeadTags = ['<style>.blue {color: blue;}</style>'];
+    const result: string = getLibraryBundleSource(components, { pageHeadTags });
+
+    // then
+    expect(result).toEqual(expectedFileString);
+  });
 });

--- a/packages/uxpin-merge-cli/src/steps/building/library/__tests__/getLibraryBundleSource.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/building/library/__tests__/getLibraryBundleSource.test.ts
@@ -10,34 +10,34 @@ describe('getLibraryBundleSource', () => {
     properties: [],
   };
 
-  it('returns content of library file for list of components', () => {
-    const components: ComponentDefinition[] = [
-      {
-        defaultExported: true,
-        info: {
-          dirPath: 'src/components/button',
-          implementation: {
-            ...commonImplementation,
-            path: 'src/components/button/button.jsx',
-          },
+  const components: ComponentDefinition[] = [
+    {
+      defaultExported: true,
+      info: {
+        dirPath: 'src/components/button',
+        implementation: {
+          ...commonImplementation,
+          path: 'src/components/button/button.jsx',
         },
-        name: 'Button',
-        ...commonProps,
       },
-      {
-        defaultExported: true,
-        info: {
-          dirPath: 'src/components/button-list',
-          implementation: {
-            ...commonImplementation,
-            path: 'src/components/button-list/button-list.jsx',
-          },
+      name: 'Button',
+      ...commonProps,
+    },
+    {
+      defaultExported: true,
+      info: {
+        dirPath: 'src/components/button-list',
+        implementation: {
+          ...commonImplementation,
+          path: 'src/components/button-list/button-list.jsx',
         },
-        name: 'ButtonList',
-        ...commonProps,
       },
-    ];
+      name: 'ButtonList',
+      ...commonProps,
+    },
+  ];
 
+  it('returns content of library file for list of components', () => {
     const expectedFileString = `import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import Button from '../src/components/button/button';
@@ -57,33 +57,6 @@ export {
   });
 
   it('returns content of library file for list of components and path of custom wrapper', () => {
-    const components: ComponentDefinition[] = [
-      {
-        defaultExported: true,
-        info: {
-          dirPath: 'src/components/button',
-          implementation: {
-            ...commonImplementation,
-            path: 'src/components/button/button.jsx',
-          },
-        },
-        name: 'Button',
-        ...commonProps,
-      },
-      {
-        defaultExported: true,
-        info: {
-          dirPath: 'src/components/button-list',
-          implementation: {
-            ...commonImplementation,
-            path: 'src/components/button-list/button-list.jsx',
-          },
-        },
-        name: 'ButtonList',
-        ...commonProps,
-      },
-    ];
-
     const wrapperPath = './wrapper/wrapper.jsx';
 
     const expectedFileString = `import * as React from 'react';
@@ -225,33 +198,6 @@ export {
   });
 
   it('handles `pageHeadTags` option to add a script in the bundle', () => {
-    const components: ComponentDefinition[] = [
-      {
-        defaultExported: true,
-        info: {
-          dirPath: 'src/components/button',
-          implementation: {
-            ...commonImplementation,
-            path: 'src/components/button/button.jsx',
-          },
-        },
-        name: 'Button',
-        ...commonProps,
-      },
-      {
-        defaultExported: true,
-        info: {
-          dirPath: 'src/components/button-list',
-          implementation: {
-            ...commonImplementation,
-            path: 'src/components/button-list/button-list.jsx',
-          },
-        },
-        name: 'ButtonList',
-        ...commonProps,
-      },
-    ];
-
     const expectedFileString = `import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import Button from '../src/components/button/button';

--- a/packages/uxpin-merge-cli/src/steps/building/library/__tests__/getLibraryBundleSource.test.ts
+++ b/packages/uxpin-merge-cli/src/steps/building/library/__tests__/getLibraryBundleSource.test.ts
@@ -100,7 +100,7 @@ export {
 };`;
 
     // when
-    const result: string = getLibraryBundleSource(components, wrapperPath);
+    const result: string = getLibraryBundleSource(components, { wrapperPath });
 
     // then
     expect(result).toEqual(expectedFileString);
@@ -218,7 +218,7 @@ export {
 };`;
 
     // when
-    const result: string = getLibraryBundleSource(components, wrapperPath);
+    const result: string = getLibraryBundleSource(components, { wrapperPath });
 
     // then
     expect(result).toEqual(expectedFileString);

--- a/packages/uxpin-merge-cli/src/steps/building/library/createComponentsLibrary.ts
+++ b/packages/uxpin-merge-cli/src/steps/building/library/createComponentsLibrary.ts
@@ -7,8 +7,11 @@ import { getLibraryBundleSource } from './getLibraryBundleSource';
 
 export async function createComponentsLibrary(
   componentInfos: ComponentDefinition[],
-  { uxpinDirPath, wrapperPath }: BuildOptions
+  { pageHeadContent, uxpinDirPath, wrapperPath }: BuildOptions
 ): Promise<void> {
   await ensureDir(uxpinDirPath);
-  await writeToFile(getComponentLibraryInputPath(uxpinDirPath), getLibraryBundleSource(componentInfos, wrapperPath));
+  await writeToFile(
+    getComponentLibraryInputPath(uxpinDirPath),
+    getLibraryBundleSource(componentInfos, { wrapperPath, pageHeadContent })
+  );
 }

--- a/packages/uxpin-merge-cli/src/steps/building/library/createComponentsLibrary.ts
+++ b/packages/uxpin-merge-cli/src/steps/building/library/createComponentsLibrary.ts
@@ -7,11 +7,11 @@ import { getLibraryBundleSource } from './getLibraryBundleSource';
 
 export async function createComponentsLibrary(
   componentInfos: ComponentDefinition[],
-  { pageHeadContent, uxpinDirPath, wrapperPath }: BuildOptions
+  { pageHeadTags, uxpinDirPath, wrapperPath }: BuildOptions
 ): Promise<void> {
   await ensureDir(uxpinDirPath);
   await writeToFile(
     getComponentLibraryInputPath(uxpinDirPath),
-    getLibraryBundleSource(componentInfos, { wrapperPath, pageHeadContent })
+    getLibraryBundleSource(componentInfos, { wrapperPath, pageHeadTags })
   );
 }

--- a/packages/uxpin-merge-cli/src/steps/building/library/getLibraryBundleSource.ts
+++ b/packages/uxpin-merge-cli/src/steps/building/library/getLibraryBundleSource.ts
@@ -34,7 +34,7 @@ export function getLibraryBundleSource(components: ComponentDefinition[], option
     `};`,
   ];
 
-  const scriptToInjectPageHeadContent = pageHeadContent && generateScriptToInjectPageHeadContent(pageHeadContent);
+  const scriptToInjectTags = pageHeadContent?.length && generateScriptToInjectTagsInPageHead(pageHeadContent);
 
   return compact([
     ...libImports,
@@ -42,7 +42,7 @@ export function getLibraryBundleSource(components: ComponentDefinition[], option
     ...wrapperImport,
     ...namespacedComponentDeclarations,
     ...exports,
-    scriptToInjectPageHeadContent,
+    scriptToInjectTags,
   ]).join('\n');
 }
 
@@ -89,12 +89,13 @@ function getNamespacedComponentDeclaration(component: ComponentDefinition): stri
   return `const ${namespace.importSlug} = ${namespace.name}.${name};`;
 }
 
-function generateScriptToInjectPageHeadContent(html: string) {
-  log('Content to be injected in page <head>', html.slice(0, 100), prettyBytes(html.length));
+function generateScriptToInjectTagsInPageHead(htmlTags: string[]) {
+  const html = htmlTags.reverse().join(''); // reverse the order before "prepending" to preserve the order of the tags
+  log(`Content to be injected in page <head> (${prettyBytes(html.length)})`, html.slice(0, 100));
   return `
 const template = document.createElement('template');
 template.innerHTML = \`${html}\`;
-const element = template.content.firstChild;
-document.head.prepend(element);
+const nodes = Array.from(template.content.children);
+nodes.forEach(node => document.head.prepend(node));
 `;
 }

--- a/packages/uxpin-merge-cli/src/steps/building/library/getLibraryBundleSource.ts
+++ b/packages/uxpin-merge-cli/src/steps/building/library/getLibraryBundleSource.ts
@@ -11,10 +11,10 @@ const CLASS_NAME_WRAPPER = 'Wrapper';
 
 const log = debug('uxpin:build');
 
-type LibraryBundleOptions = Pick<BuildOptions, 'wrapperPath' | 'pageHeadContent'>;
+type LibraryBundleOptions = Pick<BuildOptions, 'wrapperPath' | 'pageHeadTags'>;
 
 export function getLibraryBundleSource(components: ComponentDefinition[], options?: LibraryBundleOptions): string {
-  const { wrapperPath, pageHeadContent } = options || {};
+  const { wrapperPath, pageHeadTags } = options || {};
   const libImports: string[] = ["import * as React from 'react';", "import * as ReactDOM from 'react-dom';"];
 
   const imports: string[] = components
@@ -34,7 +34,7 @@ export function getLibraryBundleSource(components: ComponentDefinition[], option
     `};`,
   ];
 
-  const scriptToInjectTags = pageHeadContent?.length && generateScriptToInjectTagsInPageHead(pageHeadContent);
+  const scriptToInjectTags = pageHeadTags?.length && generateScriptToInjectTagsInPageHead(pageHeadTags);
 
   return compact([
     ...libImports,

--- a/packages/uxpin-merge-cli/src/steps/building/library/getLibraryBundleSource.ts
+++ b/packages/uxpin-merge-cli/src/steps/building/library/getLibraryBundleSource.ts
@@ -94,6 +94,6 @@ function generateScriptToInjectPageHeadContent(html: string) {
 const template = document.createElement('template');
 template.innerHTML = \`${html}\`;
 const element = template.content.firstChild;
-document.head.appendChild(element);
+document.head.prepend(element);
 `;
 }

--- a/packages/uxpin-merge-cli/src/steps/building/library/getLibraryBundleSource.ts
+++ b/packages/uxpin-merge-cli/src/steps/building/library/getLibraryBundleSource.ts
@@ -1,4 +1,5 @@
 import debug from 'debug';
+import { compact } from 'lodash';
 
 import { parse, relative, posix } from 'path';
 import prettyBytes = require('pretty-bytes');
@@ -33,16 +34,16 @@ export function getLibraryBundleSource(components: ComponentDefinition[], option
     `};`,
   ];
 
-  const scriptToInjectPageHeadContent = pageHeadContent ? generateScriptToInjectPageHeadContent(pageHeadContent) : '';
+  const scriptToInjectPageHeadContent = pageHeadContent && generateScriptToInjectPageHeadContent(pageHeadContent);
 
-  return [
+  return compact([
     ...libImports,
     ...imports,
     ...wrapperImport,
     ...namespacedComponentDeclarations,
     ...exports,
     scriptToInjectPageHeadContent,
-  ].join('\n');
+  ]).join('\n');
 }
 
 function normalizePath(path: string): string {


### PR DESCRIPTION
## Goal

Let users define in UXPin configuration some HTML content to be injected in the page `<head>`, for both UXPin Editor and Preview apps.

This addresses an issue from Porsche: they want to inject in the page global styles needed to override browser default styles.

## Strategy

- Users provide in `uxpin.config.js` the HTML content to inject in the HTML head. E.g. `<style>...</style>`
- Merge CLI reads this content and adds to the library bundle a few lines of JavaScript to inject the content in the page `<head>`
- When library components are loaded in the page, whether it's in the Editor or Preview, the script runs and inject the content at the very beginning of the `<head>`. 

Note: to avoid conflict with UXPin styles, the content is inject at the top of the `<head>` using `document.head.preprend(element)`, not at the end, so that UXPin styles can override them (and not the opposite!)

Here is the snippet added by `getLibraryBundleSource.ts` to `.uxpin-merge/conponents.js` (the entry file compiled by Webpack to generate the library bundle):

```js
const template = document.createElement('template');
template.innerHTML = `<style>...</style>`;
const element = template.content.firstChild;
document.head.prepend(element);
```

## How to test

In `uxpin.config.js` add the the content to be injected, under `components / pageHeadContent`:

```js
module.exports = {
  components: {
    pageHeadContent: require("@porsche-design-system/components-js/partials").getInitialStyles(),
    categories: [ ...
```

- Run the experimental mode
- Check that  `.uxpin-merge/conponents.js` is updated accordingly.
- Open the editor and preview: the content should have been added at the top of the page `<head>` (screenshot below)
 
## Screenshot

The editor page `<head>` with the styles coming from `require("@porsche-design-system/components-js/partials").getInitialStyles()`:

![image](https://github.com/UXPin/uxpin-merge-tools/assets/5546996/1cce093a-1ce5-4771-a94f-8019ded835ba)
