### PR TITLE
Add component description using `@uxpindescription` annotation

### DIFF
--- a/packages/uxpin-merge-cli/src/common/types/ComponentRevision.ts
+++ b/packages/uxpin-merge-cli/src/common/types/ComponentRevision.ts
@@ -7,4 +7,4 @@ export interface ComponentRevision extends ComponentDefinitionPersistedPart {
 
 export type ComponentDefinitionPersistedPart = Pick<ComponentDefinition, ComponentPersistedProps>;
 
-type ComponentPersistedProps = 'name' | 'info' | 'properties' | 'namespace' | 'wrappers' | 'usePortal';
+type ComponentPersistedProps = 'name' | 'description' | 'info' | 'properties' | 'namespace' | 'wrappers' | 'usePortal';

--- a/packages/uxpin-merge-cli/src/steps/experimentation/server/common/page/data/codeSync/component/getComponentsCollection.ts
+++ b/packages/uxpin-merge-cli/src/steps/experimentation/server/common/page/data/codeSync/component/getComponentsCollection.ts
@@ -12,6 +12,7 @@ export function getComponentsCollection({ revisionId, metadata }: ComponentsColl
     const componentId: string = getComponentId(designSystemId, component.info);
     all[componentId] = {
       componentId,
+      description: component.description,
       info: component.info,
       name: component.name,
       namespace: component.namespace,

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/CommentTags.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/CommentTags.ts
@@ -1,5 +1,6 @@
 export enum CommentTags {
   UXPIN_COMPONENT = '@uxpincomponent',
+  UXPIN_DESCRIPTION = '@uxpindescription',
   UXPIN_NAMESPACE = '@uxpinnamespace',
   UXPIN_WRAPPERS = '@uxpinwrappers',
   UXPIN_DOC_URL = '@uxpindocurl',

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/ComponentDefinition.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/ComponentDefinition.ts
@@ -5,6 +5,7 @@ import { ComponentPreset } from './presets/ComponentPreset';
 import { ComponentWrapper } from './wrappers/ComponentWrapper';
 
 export interface ComponentMetadata {
+  description?: string;
   name: string;
   namespace?: ComponentNamespace;
   componentDocUrl?: string;

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/comments/jsdoc-uxpin-annotations.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/comments/jsdoc-uxpin-annotations.ts
@@ -5,6 +5,10 @@ import { ComponentNamespace } from '../../../ComponentDefinition';
 import { getComponentNamespaceImportSlug } from '../../getComponentNamespaceImportSlug';
 import { extractMultipleWordsFromJsDocTags, extractSingleWordFromJsDocTags } from './jsdoc-helpers';
 
+export function getComponentDescriptionFromJsDocTags(jsDocTags: string[]) {
+  return extractMultipleWordsFromJsDocTags(CommentTags.UXPIN_DESCRIPTION, jsDocTags);
+}
+
 export function getComponentDocUrlFromJsDocTags(jsDocTags: string[]) {
   return extractSingleWordFromJsDocTags(CommentTags.UXPIN_DOC_URL, jsDocTags);
 }

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/serializeJSComponent.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/javascript/serializeJSComponent.ts
@@ -17,6 +17,7 @@ import { ImplSerializationResult } from '../ImplSerializationResult';
 import { PropDefinitionParsingResult } from '../PropDefinitionParsingResult';
 import { PropDefinitionSerializationResult } from '../PropDefinitionSerializationResult';
 import {
+  getComponentDescriptionFromJsDocTags,
   getComponentDocUrlFromJsDocTags,
   getComponentNamespaceFromJsDocTags,
   getComponentUsePortalFromJsDocTags,
@@ -71,16 +72,17 @@ function getComponentWrappers(parsed: ComponentDoc, implInfo: ComponentImplement
 function getValuesFromComments(
   name: string,
   parsed: ComponentDoc
-): Pick<PartialResult, 'namespace' | 'componentDocUrl' | 'usePortal'> {
+): Pick<PartialResult, 'description' | 'namespace' | 'componentDocUrl' | 'usePortal'> {
   const jsDocTags: string[] = getJSDocTagsArrayFromString(parsed.description);
 
+  const description = getComponentDescriptionFromJsDocTags(jsDocTags);
   const namespace: ComponentNamespace | undefined = getComponentNamespaceFromJsDocTags(name, jsDocTags);
   const componentDocUrl: string | undefined = getComponentDocUrlFromJsDocTags(jsDocTags);
 
   const usePortal: boolean | string | undefined = getComponentUsePortalFromJsDocTags(jsDocTags);
   if (usePortal) log(`Portal component detected`, name, usePortal);
 
-  return { namespace, componentDocUrl, usePortal };
+  return { description, namespace, componentDocUrl, usePortal };
 }
 
 function thunkGetSummaryResult(path: string): (propResults: PartialResult) => ImplSerializationResult {
@@ -95,6 +97,7 @@ function thunkGetSummaryResult(path: string): (propResults: PartialResult) => Im
 }
 
 interface PartialResult {
+  description?: string;
   name: string;
   namespace?: ComponentNamespace;
   componentDocUrl?: string;

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/comments/jsdoc-uxpin-annotations.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/comments/jsdoc-uxpin-annotations.ts
@@ -7,6 +7,12 @@ import { ComponentDeclaration } from '../component/getPropsTypeAndDefaultProps';
 import { getComponentNamespaceImportSlug } from '../../getComponentNamespaceImportSlug';
 import { getJSDocCommentText, getNodeJsDocTag } from './jsdoc-helpers';
 
+export function getComponentDescription(component: ts.Node): string | undefined {
+  const jsDocTag: ts.JSDocTag | undefined = getNodeJsDocTag(component, CommentTags.UXPIN_DESCRIPTION);
+  if (!jsDocTag) return undefined;
+  return getJSDocCommentText(jsDocTag);
+}
+
 export function getComponentDocUrl(component: ts.Node): string | undefined {
   const componentDocUrl: ts.JSDocTag | undefined = getNodeJsDocTag(component, CommentTags.UXPIN_DOC_URL);
   if (!componentDocUrl) return undefined;

--- a/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/serializeTSComponent.ts
+++ b/packages/uxpin-merge-cli/src/steps/serialization/component/implementation/typescript/serializeTSComponent.ts
@@ -12,7 +12,12 @@ import { ImplSerializationResult } from '../ImplSerializationResult';
 import { PropDefinitionParsingResult } from '../PropDefinitionParsingResult';
 import { PropDefinitionSerializationResult } from '../PropDefinitionSerializationResult';
 import { getComponentDeclaration } from './component/getComponentDeclaration';
-import { getComponentDocUrl, getComponentNamespace, getComponentUsePortal } from './comments/jsdoc-uxpin-annotations';
+import {
+  getComponentDescription,
+  getComponentDocUrl,
+  getComponentNamespace,
+  getComponentUsePortal,
+} from './comments/jsdoc-uxpin-annotations';
 import { getComponentName } from './component/getComponentName';
 import { getComponentWrappers } from './component/getComponentWrappers';
 import { ComponentDeclaration } from './component/getPropsTypeAndDefaultProps';
@@ -41,6 +46,7 @@ export async function serializeTSComponentWithProgram(component: ComponentImplem
   const parsedProps: PropDefinitionParsingResult[] = parseTSComponentProperties(context, declaration);
   const validatedProps: PropDefinitionSerializationResult[] = serializeAndValidateParsedProperties(parsedProps);
   const namespace: ComponentNamespace | undefined = getComponentNamespace(declaration, name);
+  const description: string | undefined = getComponentDescription(declaration);
   const componentDocUrl: string | undefined = getComponentDocUrl(declaration);
   const wrappers: ComponentWrapper[] = getComponentWrappers(declaration);
   const validatedWrappers: Warned<ComponentWrapper[]> = validateWrappers(wrappers, component);
@@ -53,6 +59,7 @@ export async function serializeTSComponentWithProgram(component: ComponentImplem
     result: {
       componentDocUrl,
       defaultExported,
+      description,
       name,
       namespace,
       properties: validatedProps.map(({ result }) => result),


### PR DESCRIPTION
## Goal

Let users specify component description by adding a JSDoc annotation `@uxpindescription`

The component description could be displayed in the UXPin editor.

From a request mentioned by @jackbehar:

> They want to be able to pass component description for the designer to be able to see in the props panel